### PR TITLE
Refactoring combine-separate

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,8 +91,7 @@
       , brush = BrushView()
       , colorLegend = ColorLegend()
       , colorScale = d3.scale.category10()
-      , tip = d3.tip()
-              .attr("class", "d3-tip")
+      , tip = d3.tip().attr("class", "d3-tip")
     ;
     var defaultWork = "Jos2721-La_Bernardina"
       , hash = window.location.hash
@@ -155,18 +154,16 @@
 
         // When the user brushes in the context view,
         signal.on("zoom.extent", function (zoom){
-            var extent = zoom.extent;
+            // Update the focus view.
+            notesViewFocus.zoom(zoom.extent);
 
+            /*
             // Filter the notes based on the selected time interval.
             var filteredData = data.notes
                 .filter(function (d){
                     return d.time > extent[0] && d.time < extent[1];
                   })
             ;
-            // Update the focus view.
-            notesViewFocus.xDomain(extent);
-            renderNotesViewFocus(filteredData);
-
             // Update the pitch names text.
             var pitchNames = filteredData
                 .map(function (d){ return d.pitchName; })
@@ -181,18 +178,18 @@
             d3.select("#note-durations-string")
                 .text(pitchNames.join(", "))
             ;
+            */
           })
         ;
+        // When the user clicks on a legend item, they are either:
+        //  1. selecting a voice to highlight
+        //  2. deselecting it to show all voices.
+        signal.on("hilite", notesViewFocus.hilite);
         // When the user selects to separate or combine...
         signal.on("separate", function (separate){
            notesViewFocus.separate(separate);
            renderNotesViewFocus(data.notes);
          })
-        ;
-        // When the user higlights/unhilights from the legend
-        signal.on("hilite", function(hilite) {
-            notesViewFocus.hilite(hilite);
-          })
         ;
     }
 

--- a/index.html
+++ b/index.html
@@ -145,8 +145,9 @@
 
         colorLegend.connect(signal);
 
-        combineSeparateUI.connect(signal);
-
+        d3.select("#combine-separate-ui")
+            .call(combineSeparateUI.connect(signal))
+        ;
         renderNotesViewContext(data.notes);
         renderNotesViewFocus(data.notes);
         renderColorLegend(data.notes);
@@ -185,7 +186,6 @@
 
         // When the user selects to separate or combine...
         signal.on("separate", function (separate){
-           console.log("separate: " + separate);
            notesViewContext.separate(separate);
            renderNotesViewContext(data.notes);
         });

--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@ return prollData;
            renderNotesViewFocus(data.notes);
          })
         ;
-    }
+    } // chartify()
 
     function renderNotesViewContext(data){
         notesViewContextSVG
@@ -183,19 +183,19 @@ return prollData;
             .call(notesViewContext)
             .call(brush.x(notesViewContext.x()))
         ;
-    }
+    } // renderNotesViewContext()
     function renderNotesViewFocus(data){
         notesViewFocusSVG
             .datum(data)
             .call(notesViewFocus)
         ;
-    }
+    } // renderNotesViewFocus()
     function renderColorLegend(data){
         colorLegend
             .noteHeight(notesViewContext.noteHeight())
             .roundedCornerSize(notesViewContext.roundedCornerSize())
         ;
         colorLegend();
-    }
+    } // renderColorLegend()
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -104,21 +104,34 @@
     colorLegend.colorScale(colorScale);
 
     function parseJSON(prollData){
-        prollData.notes = [];
-        prollData.partdata.forEach(function (part){
-            var voice = prollData.partnames[part.partindex];
-            part.notedata.forEach(function (note){
-                prollData.notes.push({
-                    pitch: note.pitch.b7,
-                    pitchName: note.pitch.name,
-                    time: note.starttime[0],
-                    duration: note.duration[0],
-                    voice: voice
+        var notes = []
+          , voice
+        ;
+        prollData.partdata.forEach(function(part) {
+            voice = prollData.partnames[part.partindex];
+            part.notedata.forEach(function(note) {
+                notes.push({
+                      pitch: note.pitch.b7
+                    , pitchName: note.pitch.name
+                    , time: note.starttime[0]
+                    , duration: note.duration[0]
+                    , voice: voice
                 });
             });
         });
+        // Group the notes by voice
+        prollData.notes = d3.nest()
+            .key(function(d) { return d.voice; })
+            .map(notes, d3.map)
+        ;
+        prollData.pitches = d3.extent(notes, function(d) { return d.pitch; });
+        prollData.times = [
+              d3.min(notes, function(d) { return d.time; })
+            , d3.max(notes, function(d) { return d.time + d.duration; })
+          ]
+        ;
         return prollData;
-    }
+    } // parseJSON()
 
     function chartify(data){
         var signal = d3.dispatch("hilite", "zoom", "separate");

--- a/index.html
+++ b/index.html
@@ -142,7 +142,11 @@
             data.notes.map(function (d){ return d.voice; })
           )
         ;
+
         colorLegend.connect(signal);
+
+        combineSeparateUI.connect(signal);
+
         renderNotesViewContext(data.notes);
         renderNotesViewFocus(data.notes);
         renderColorLegend(data.notes);

--- a/index.html
+++ b/index.html
@@ -90,7 +90,6 @@
       , work = hash ? hash.substr(1) : defaultWork
       , jsonURL = "http://josquin.stanford.edu/cgi-bin/jrp?a=proll-json&f=" + work
       , colorScale = d3.scale.category10()
-      , notesViewFocus = NotesView()
     ;
 
     colorLegend.colorScale(colorScale);

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
 
         // When the user brushes in the context view,
         signal.on("zoom.extent", function (zoom){
-           var extent = zoom.extent;
+            var extent = zoom.extent;
 
             // Filter the notes based on the selected time interval.
             var filteredData = data.notes.filter(function (d){

--- a/index.html
+++ b/index.html
@@ -72,16 +72,22 @@
         <div id="notes" class="col-xs-12 col-lg-10">
         </div>
 
-        <form class="form">
-          <label class="radio-inline">
-            <input type="radio"> Combine
-          </label>
-          <label class="radio-inline">
-            <input type="radio"> Separate
-          </label>
-        </form>
+        <div class="col-xs-12 col-lg-2">
 
-        <div id="legend" class="col-xs-12 col-lg-2"></div>
+          <div>
+            <form class="form">
+              <label class="radio-inline">
+                <input type="radio"> Combine
+              </label>
+              <label class="radio-inline">
+                <input type="radio"> Separate
+              </label>
+            </form>
+          </div>
+
+          <div id="legend"></div>
+
+        </div>
       </div><!--.row-->
       <div class="row">
         <span>Note names: </span> <p id="note-names-string"></p>

--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
     });
 
     function chartify(data){
-        var signal = d3.dispatch("hilite", "zoom");
+        var signal = d3.dispatch("hilite", "zoom", "separate");
 
         notesViewContext
             .colorScale(colorScale)
@@ -181,6 +181,11 @@
                 return d.duration;
             }).join(", ");
             d3.select("#note-durations-string").text(pitchNames);
+        });
+
+        // When the user selects to separate or combine...
+        signal.on("separate", function (separate){
+           console.log("separate: " + separate);
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -107,10 +107,12 @@
       , work = hash ? hash.substr(1) : defaultWork
       , jsonURL = "http://josquin.stanford.edu/cgi-bin/jrp?a=proll-json&f=" + work
     ;
-    d3.json(jsonURL, function (err, prollData){
-        chartify(parseJSON(prollData));
-    });
     colorLegend.colorScale(colorScale);
+
+    d3.json(jsonURL, function (error, proll){
+        if(error) throw error;
+        chartify(parseJSON(proll));
+    });
 
     function parseJSON(prollData){
         var notes = []

--- a/index.html
+++ b/index.html
@@ -71,6 +71,16 @@
       <div class="row">
         <div id="notes" class="col-xs-12 col-lg-10">
         </div>
+
+        <form class="form">
+          <label class="radio-inline">
+            <input type="radio"> Combine
+          </label>
+          <label class="radio-inline">
+            <input type="radio"> Separate
+          </label>
+        </form>
+
         <div id="legend" class="col-xs-12 col-lg-2"></div>
       </div><!--.row-->
       <div class="row">

--- a/index.html
+++ b/index.html
@@ -185,7 +185,10 @@
         // When the user clicks on a legend item, they are either:
         //  1. selecting a voice to highlight
         //  2. deselecting it to show all voices.
-        signal.on("hilite", notesViewFocus.hilite);
+        signal.on("hilite", function(hilite) {
+            notesViewFocus.hilite(hilite);
+          })
+        ;
         // When the user selects to separate or combine...
         signal.on("separate", function (separate){
            notesViewFocus.separate(separate);

--- a/index.html
+++ b/index.html
@@ -57,7 +57,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.min.js"></script>
   <script src="js/legend.js"></script>
-  <script src="js/notesview.js"></script>
+  <script src="js/notescanvas.js"></script>
+  <script src="js/brushview.js"></script>
   <script src="js/combineSeparateUI.js"></script>
 </head>
 
@@ -87,6 +88,7 @@
       , notesViewFocus = NotesView()
       , notesViewFocusSVG = d3.select("#notes").append("svg")
       , combineSeparateUI = CombineSeparateUI()
+      , brush = BrushView()
       , colorLegend = ColorLegend()
       , colorScale = d3.scale.category10()
       , tip = d3.tip()
@@ -126,7 +128,6 @@
             .colorScale(colorScale)
             .width(900)
             .height(150)
-            .brushEnabled(true)
             .connect(signal)
         ;
         notesViewFocus
@@ -150,6 +151,8 @@
         renderNotesViewFocus(data.notes);
         renderColorLegend(data.notes);
 
+        brush.connect(signal);
+
         // When the user brushes in the context view,
         signal.on("zoom.extent", function (zoom){
             var extent = zoom.extent;
@@ -158,7 +161,7 @@
             var filteredData = data.notes
                 .filter(function (d){
                     return d.time > extent[0] && d.time < extent[1];
-                })
+                  })
             ;
             // Update the focus view.
             notesViewFocus.xDomain(extent);
@@ -191,16 +194,15 @@
         notesViewContextSVG
             .datum(data)
             .call(notesViewContext)
+            .call(brush.x(notesViewContext.x()))
         ;
     }
-
     function renderNotesViewFocus(data){
         notesViewFocusSVG
             .datum(data)
             .call(notesViewFocus)
         ;
     }
-
     function renderColorLegend(data){
         colorLegend
             .noteHeight(notesViewContext.noteHeight())

--- a/index.html
+++ b/index.html
@@ -87,7 +87,6 @@
       , colorLegend = ColorLegend()
       , jsonURL = "http://josquin.stanford.edu/cgi-bin/jrp?a=proll-json&f=Jos2721-La_Bernardina"
       , colorScale = d3.scale.category10()
-      , notesViewFocus = NotesView()
     ;
 
     colorLegend.colorScale(colorScale);

--- a/index.html
+++ b/index.html
@@ -145,7 +145,6 @@
             .domain(data.partnames)
         ;
         notesViewContext
-            .full([[0, data.scorelength], [data.minpitch.b7, data.maxpitch.b7]])
             .colorScale(colorScale)
             .width(width)
             .height(height)
@@ -154,7 +153,7 @@
         notesViewFocus
             .colorScale(colorScale)
             .width(width)
-            .height(height)
+            .height(height * 3)
             .tooltip(tip)
             .connect(signal)
         ;
@@ -168,12 +167,16 @@
         renderNotesViewContext(data.notes);
         renderNotesViewFocus(data);
 
+        var full = [[0, data.scorelength], [data.minpitch.b7, data.maxpitch.b7]];
+        notesViewContext.zoom(full);
+        notesViewFocus.zoom(full);
+
         brush
             .height(150)
             .connect(signal)
         ;
         // When the user brushes in the context view,
-        signal.on("zoom.extent", function (zoom){
+        signal.on("zoom", function (zoom){
             // Update the focus view.
             notesViewFocus.zoom(zoom.extent, zoom.ended);
 

--- a/index.html
+++ b/index.html
@@ -133,9 +133,8 @@
             .colorScale(colorScale)
             .width(notesViewContext.width())
             .height(450)
-            .tipEnabled(true)
-            .connect(signal)
             .tooltip(tip)
+            .connect(signal)
         ;
         colorScale.domain(
             data.notes.map(function (d){ return d.voice; })

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.min.js"></script>
   <script src="js/legend.js"></script>
   <script src="js/notescanvas.js"></script>
+  <script src="js/notesbook.js"></script>
   <script src="js/brushview.js"></script>
   <script src="js/combineSeparateUI.js"></script>
 </head>
@@ -85,7 +86,7 @@
   <script>
     var notesViewContext = NotesCanvas()
       , notesViewContextSVG = d3.select("#notes").append("svg")
-      , notesViewFocus = NotesCanvas()
+      , notesViewFocus = NotesBook()
       , notesViewFocusSVG = d3.select("#notes").append("svg")
       , combineSeparateUI = CombineSeparateUI()
       , brush = BrushView()
@@ -124,13 +125,7 @@
             .key(function(d) { return d.voice; })
             .map(notes, d3.map)
         ;
-        prollData.pitches = d3.extent(notes, function(d) { return d.pitch; });
-        prollData.times = [
-              d3.min(notes, function(d) { return d.time; })
-            , d3.max(notes, function(d) { return d.time + d.duration; })
-          ]
-        ;
-        return prollData;
+return prollData;
     } // parseJSON()
 
     function chartify(data){
@@ -140,6 +135,7 @@
             .colorScale(colorScale)
             .width(900)
             .height(150)
+            .full([[0, data.scorelength], [data.minpitch.b7, data.maxpitch.b7]])
             .connect(signal)
         ;
         notesViewFocus
@@ -147,14 +143,10 @@
             .width(notesViewContext.width())
             .height(450)
             .tooltip(tip)
+//            .full([[0, data.scorelength], [data.minpitch.b7, data.maxpitch.b7]])
             .connect(signal)
         ;
-        colorScale.domain(
-            data.notes.map(function (d){ return d.voice; })
-          )
-        ;
-
-        colorLegend.connect(signal);
+        colorScale.domain(data.notes.keys());
 
         d3.select("#combine-separate-ui")
             .call(combineSeparateUI.connect(signal))
@@ -163,6 +155,7 @@
         renderNotesViewFocus(data.notes);
         renderColorLegend(data.notes);
 
+        colorLegend.connect(signal);
         brush.connect(signal);
 
         // When the user brushes in the context view,

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
     function renderNotesViewContext(data) {
         notesViewContextSVG
           .append("g")
-            .datum({ key: "full", value: d3.merge((data.value())) })
+            .datum({ key: "full", value: d3.merge((data.values())) })
             .call(notesViewContext)
             .call(brush.x(notesViewContext.x()))
         ;

--- a/index.html
+++ b/index.html
@@ -77,10 +77,10 @@
           <div>
             <form class="form">
               <label class="radio-inline">
-                <input type="radio"> Combine
+                <input type="radio" name="combine-separate-group"> Combine
               </label>
               <label class="radio-inline">
-                <input type="radio"> Separate
+                <input type="radio" name="combine-separate-group"> Separate
               </label>
             </form>
           </div>

--- a/index.html
+++ b/index.html
@@ -177,10 +177,6 @@
                 return d.duration;
             }).join(", ");
             d3.select("#note-durations-string").text(pitchNames);
-
-            // TODO For the text entries, we may need to filter by the voice
-            // that is currently selected from the legend. Currently, these
-            // show notes from all voices combined, and not in temporal order.
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -146,8 +146,9 @@ return prollData;
 //            .full([[0, data.scorelength], [data.minpitch.b7, data.maxpitch.b7]])
             .connect(signal)
         ;
-        colorScale.domain(data.notes.keys());
-
+        colorScale
+            .domain(data.partnames)
+        ;
         d3.select("#combine-separate-ui")
             .call(combineSeparateUI.connect(signal))
         ;
@@ -161,7 +162,7 @@ return prollData;
         // When the user brushes in the context view,
         signal.on("zoom.extent", function (zoom){
             // Update the focus view.
-            notesViewFocus.zoom(zoom.extent);
+            notesViewFocus.zoom(zoom.extent, zoom.ended);
           })
         ;
         // When the user clicks on a legend item, they are either:

--- a/index.html
+++ b/index.html
@@ -187,7 +187,13 @@
         signal.on("separate", function (separate){
            notesViewFocus.separate(separate);
            renderNotesViewFocus(data.notes);
-        });
+         })
+        ;
+        // When the user higlights/unhilights from the legend
+        signal.on("hilite", function(hilite) {
+            notesViewFocus.hilite(hilite);
+          })
+        ;
     }
 
     function renderNotesViewContext(data){

--- a/index.html
+++ b/index.html
@@ -186,6 +186,8 @@
         // When the user selects to separate or combine...
         signal.on("separate", function (separate){
            console.log("separate: " + separate);
+           notesViewContext.separate(separate);
+           renderNotesViewContext(data.notes);
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
         notesViewFocus.zoom(full);
 
         brush
-            .height(150)
+            .height(height)
             .connect(signal)
         ;
         // When the user brushes in the context view,

--- a/index.html
+++ b/index.html
@@ -101,20 +101,20 @@
     colorLegend.colorScale(colorScale);
 
     function parseJSON(prollData){
-      prollData.notes = [];
-      prollData.partdata.forEach(function (part){
-          var voice = prollData.partnames[part.partindex];
-          part.notedata.forEach(function (note){
-              prollData.notes.push({
-                pitch: note.pitch.b7,
-                pitchName: note.pitch.name,
-                time: note.starttime[0],
-                duration: note.duration[0],
-                voice: voice
-              });
-          });
-      });
-      return prollData;
+        prollData.notes = [];
+        prollData.partdata.forEach(function (part){
+            var voice = prollData.partnames[part.partindex];
+            part.notedata.forEach(function (note){
+                prollData.notes.push({
+                    pitch: note.pitch.b7,
+                    pitchName: note.pitch.name,
+                    time: note.starttime[0],
+                    duration: note.duration[0],
+                    voice: voice
+                });
+            });
+        });
+        return prollData;
     }
 
     d3.json(jsonURL, function (err, prollData){

--- a/index.html
+++ b/index.html
@@ -194,21 +194,21 @@
         ;
     } // chartify()
 
-    function renderNotesViewContext(data){
+    function renderNotesViewContext(data) {
         notesViewContextSVG
           .append("g")
-            .datum({ key: "full", values: d3.merge((data.value())) })
+            .datum({ key: "full", value: d3.merge((data.value())) })
             .call(notesViewContext)
             .call(brush.x(notesViewContext.x()))
         ;
     } // renderNotesViewContext()
-    function renderNotesViewFocus(data){
+    function renderNotesViewFocus(data) {
         notesViewFocusSVG
-            .datum(data)
+            .datum(data.notes.entries())
             .call(notesViewFocus)
         ;
     } // renderNotesViewContext()
-    function renderColorLegend(){
+    function renderColorLegend() {
         colorLegend
             .noteHeight(notesViewContext.noteHeight())
             .roundedCornerSize(notesViewContext.roundedCornerSize())

--- a/index.html
+++ b/index.html
@@ -196,7 +196,8 @@
 
     function renderNotesViewContext(data){
         notesViewContextSVG
-            .datum({ key: "full", values: d3.merge((data.values())) })
+          .append("g")
+            .datum({ key: "full", values: d3.merge((data.value())) })
             .call(notesViewContext)
             .call(brush.x(notesViewContext.x()))
         ;

--- a/index.html
+++ b/index.html
@@ -109,17 +109,17 @@
     ;
     colorLegend.colorScale(colorScale);
 
-    d3.json(jsonURL, function (error, proll){
+    d3.json(jsonURL, function(error, proll) {
         if(error) throw error;
         chartify(parseJSON(proll));
     });
 
-    function parseJSON(prollData){
+    function parseJSON(proll) {
         var notes = []
           , voice
         ;
-        prollData.partdata.forEach(function(part) {
-            voice = prollData.partnames[part.partindex];
+        proll.partdata.forEach(function(part) {
+            voice = proll.partnames[part.partindex];
             part.notedata.forEach(function(note) {
                 notes.push({
                       pitch: note.pitch.b7
@@ -131,11 +131,11 @@
             });
         });
         // Group the notes by voice
-        prollData.notes = d3.nest()
+        proll.notes = d3.nest()
             .key(function(d) { return d.voice; })
             .map(notes, d3.map)
         ;
-        return prollData;
+        return proll;
     } // parseJSON()
 
     function chartify(data) {

--- a/index.html
+++ b/index.html
@@ -84,10 +84,18 @@
     </div><!--.container-->
   </article>
   <script>
-    var notesViewContext = NotesCanvas()
-      , notesViewContextSVG = d3.select("#notes").append("svg")
+    var width = 960
+      , height = 150 // height of one strip of notes
+      , notesViewContext = NotesCanvas()
+      , notesViewContextSVG = d3.select("#notes")
+          .append("svg")
+            .attr("width", width)
+            .attr("height", height)
       , notesViewFocus = NotesBook()
-      , notesViewFocusSVG = d3.select("#notes").append("svg")
+      , notesViewFocusSVG = d3.select("#notes")
+          .append("svg")
+            .attr("width", width)
+            .attr("height", 3 * height)
       , combineSeparateUI = CombineSeparateUI()
       , brush = BrushView()
       , colorLegend = ColorLegend()
@@ -125,44 +133,48 @@
             .key(function(d) { return d.voice; })
             .map(notes, d3.map)
         ;
-return prollData;
+        return prollData;
     } // parseJSON()
 
-    function chartify(data){
+    function chartify(data) {
         var signal = d3.dispatch("hilite", "zoom", "separate");
 
+        colorScale
+            .domain(data.partnames)
+        ;
         notesViewContext
-            .colorScale(colorScale)
-            .width(900)
-            .height(150)
             .full([[0, data.scorelength], [data.minpitch.b7, data.maxpitch.b7]])
+            .colorScale(colorScale)
+            .width(width)
+            .height(height)
             .connect(signal)
         ;
         notesViewFocus
             .colorScale(colorScale)
-            .width(notesViewContext.width())
-            .height(450)
+            .width(width)
+            .height(height)
             .tooltip(tip)
-//            .full([[0, data.scorelength], [data.minpitch.b7, data.maxpitch.b7]])
             .connect(signal)
         ;
-        colorScale
-            .domain(data.partnames)
+        colorLegend
+            .connect(signal)
         ;
         d3.select("#combine-separate-ui")
             .call(combineSeparateUI.connect(signal))
         ;
+        renderColorLegend();
         renderNotesViewContext(data.notes);
-        renderNotesViewFocus(data.notes);
-        renderColorLegend(data.notes);
+        renderNotesViewFocus(data);
 
-        colorLegend.connect(signal);
-        brush.connect(signal);
-
+        brush
+            .height(150)
+            .connect(signal)
+        ;
         // When the user brushes in the context view,
         signal.on("zoom.extent", function (zoom){
             // Update the focus view.
             notesViewFocus.zoom(zoom.extent, zoom.ended);
+
           })
         ;
         // When the user clicks on a legend item, they are either:
@@ -179,7 +191,7 @@ return prollData;
 
     function renderNotesViewContext(data){
         notesViewContextSVG
-            .datum(data)
+            .datum({ key: "full", values: d3.merge((data.values())) })
             .call(notesViewContext)
             .call(brush.x(notesViewContext.x()))
         ;
@@ -189,8 +201,8 @@ return prollData;
             .datum(data)
             .call(notesViewFocus)
         ;
-    } // renderNotesViewFocus()
-    function renderColorLegend(data){
+    } // renderNotesViewContext()
+    function renderColorLegend(){
         colorLegend
             .noteHeight(notesViewContext.noteHeight())
             .roundedCornerSize(notesViewContext.roundedCornerSize())

--- a/index.html
+++ b/index.html
@@ -210,8 +210,8 @@
     } // renderNotesViewContext()
     function renderColorLegend() {
         colorLegend
-            .noteHeight(notesViewContext.noteHeight())
-            .roundedCornerSize(notesViewContext.roundedCornerSize())
+            .noteHeight(10)
+            .roundedCornerSize(5)
         ;
         colorLegend();
     } // renderColorLegend()

--- a/index.html
+++ b/index.html
@@ -53,7 +53,6 @@
           color: #fff;
           border-radius: 2px;
       }
-
   </style>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.min.js"></script>
@@ -97,7 +96,9 @@
       , work = hash ? hash.substr(1) : defaultWork
       , jsonURL = "http://josquin.stanford.edu/cgi-bin/jrp?a=proll-json&f=" + work
     ;
-
+    d3.json(jsonURL, function (err, prollData){
+        chartify(parseJSON(prollData));
+    });
     colorLegend.colorScale(colorScale);
 
     function parseJSON(prollData){
@@ -117,10 +118,6 @@
         return prollData;
     }
 
-    d3.json(jsonURL, function (err, prollData){
-        chartify(parseJSON(prollData));
-    });
-
     function chartify(data){
         var signal = d3.dispatch("hilite", "zoom", "separate");
 
@@ -134,7 +131,7 @@
         notesViewFocus
             .colorScale(colorScale)
             .width(notesViewContext.width())
-            .height(notesViewContext.height())
+            .height(450)
             .tipEnabled(true)
             .connect(signal)
         ;

--- a/index.html
+++ b/index.html
@@ -83,9 +83,9 @@
     </div><!--.container-->
   </article>
   <script>
-    var notesViewContext = NotesView()
+    var notesViewContext = NotesCanvas()
       , notesViewContextSVG = d3.select("#notes").append("svg")
-      , notesViewFocus = NotesView()
+      , notesViewFocus = NotesCanvas()
       , notesViewFocusSVG = d3.select("#notes").append("svg")
       , combineSeparateUI = CombineSeparateUI()
       , brush = BrushView()

--- a/index.html
+++ b/index.html
@@ -155,33 +155,31 @@
             var extent = zoom.extent;
 
             // Filter the notes based on the selected time interval.
-            var filteredData = data.notes.filter(function (d){
-                return d.time > extent[0] && d.time < extent[1];
-            });
-
+            var filteredData = data.notes
+                .filter(function (d){
+                    return d.time > extent[0] && d.time < extent[1];
+                })
+            ;
             // Update the focus view.
             notesViewFocus.xDomain(extent);
             renderNotesViewFocus(filteredData);
 
             // Update the pitch names text.
-            var pitchNames = filteredData.map(function (d){
-                return d.pitchName;
-            }).join(", ");
-            d3.select("#note-names-string").text(pitchNames);
-
-            // Update the note names text.
-            var pitchNames = filteredData.map(function (d){
-                return d.pitchName;
-            }).join(", ");
-            d3.select("#note-names-string").text(pitchNames);
-
+            var pitchNames = filteredData
+                .map(function (d){ return d.pitchName; })
+            ;
+            d3.select("#note-names-string")
+                .text(pitchNames.join(", "))
+            ;
             // Update the note durations text.
-            var pitchNames = filteredData.map(function (d){
-                return d.duration;
-            }).join(", ");
-            d3.select("#note-durations-string").text(pitchNames);
-        });
-
+            pitchNames = filteredData
+                .map(function (d){ return d.duration; })
+            ;
+            d3.select("#note-durations-string")
+                .text(pitchNames.join(", "))
+            ;
+          })
+        ;
         // When the user selects to separate or combine...
         signal.on("separate", function (separate){
            notesViewFocus.separate(separate);

--- a/index.html
+++ b/index.html
@@ -162,29 +162,6 @@ return prollData;
         signal.on("zoom.extent", function (zoom){
             // Update the focus view.
             notesViewFocus.zoom(zoom.extent);
-
-            /*
-            // Filter the notes based on the selected time interval.
-            var filteredData = data.notes
-                .filter(function (d){
-                    return d.time > extent[0] && d.time < extent[1];
-                  })
-            ;
-            // Update the pitch names text.
-            var pitchNames = filteredData
-                .map(function (d){ return d.pitchName; })
-            ;
-            d3.select("#note-names-string")
-                .text(pitchNames.join(", "))
-            ;
-            // Update the note durations text.
-            pitchNames = filteredData
-                .map(function (d){ return d.duration; })
-            ;
-            d3.select("#note-durations-string")
-                .text(pitchNames.join(", "))
-            ;
-            */
           })
         ;
         // When the user clicks on a legend item, they are either:

--- a/index.html
+++ b/index.html
@@ -89,8 +89,9 @@
       , combineSeparateUI = CombineSeparateUI()
       , colorLegend = ColorLegend()
       , colorScale = d3.scale.category10()
+      , tip = d3.tip()
+              .attr("class", "d3-tip")
     ;
-
     var defaultWork = "Jos2721-La_Bernardina"
       , hash = window.location.hash
       , work = hash ? hash.substr(1) : defaultWork
@@ -134,6 +135,7 @@
             .height(450)
             .tipEnabled(true)
             .connect(signal)
+            .tooltip(tip)
         ;
         colorScale.domain(
             data.notes.map(function (d){ return d.voice; })

--- a/index.html
+++ b/index.html
@@ -175,25 +175,22 @@
             .height(height)
             .connect(signal)
         ;
-        // When the user brushes in the context view,
-        signal.on("zoom", function (zoom){
-            // Update the focus view.
-            notesViewFocus.zoom(zoom.extent, zoom.ended);
-
-          })
-        ;
-        // When the user clicks on a legend item, they are either:
-        //  1. selecting a voice to highlight
-        //  2. deselecting it to show all voices.
-        signal.on("hilite", function(hilite) {
-            notesViewFocus.hilite(hilite);
-          })
-        ;
-        // When the user selects to separate or combine...
-        signal.on("separate", function (separate){
-           notesViewFocus.separate(separate);
-           renderNotesViewFocus(data.notes);
-         })
+        signal
+            .on("zoom", function(zoom) {
+                // When the user brushes in the context view,
+                // Update the focus view.
+                notesViewFocus.zoom(zoom.extent, zoom.ended);
+              })
+            .on("hilite", function(hilite) {
+                // When the user clicks on a legend item, they are either:
+                //  1. selecting a voice to highlight
+                //  2. deselecting it to show all voices.
+                // When the user selects to separate or combine...
+                notesViewFocus.hilite(hilite);
+              })
+            .on("separate", function (separate){
+               notesViewFocus.separate(separate);
+              })
         ;
     } // chartify()
 

--- a/index.html
+++ b/index.html
@@ -183,8 +183,8 @@
 
         // When the user selects to separate or combine...
         signal.on("separate", function (separate){
-           notesViewContext.separate(separate);
-           renderNotesViewContext(data.notes);
+           notesViewFocus.separate(separate);
+           renderNotesViewFocus(data.notes);
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.min.js"></script>
   <script src="js/legend.js"></script>
   <script src="js/notesview.js"></script>
+  <script src="js/combineSeparateUI.js"></script>
 </head>
 
 <body>
@@ -69,24 +70,10 @@
   <article>
     <div class="container">
       <div class="row">
-        <div id="notes" class="col-xs-12 col-lg-10">
-        </div>
-
+        <div id="notes" class="col-xs-12 col-lg-10"></div>
         <div class="col-xs-12 col-lg-2">
-
-          <div>
-            <form class="form">
-              <label class="radio-inline">
-                <input type="radio" name="combine-separate-group"> Combine
-              </label>
-              <label class="radio-inline">
-                <input type="radio" name="combine-separate-group"> Separate
-              </label>
-            </form>
-          </div>
-
+          <div id="combine-separate-ui"></div>
           <div id="legend"></div>
-
         </div>
       </div><!--.row-->
       <div class="row">
@@ -100,12 +87,15 @@
       , notesViewContextSVG = d3.select("#notes").append("svg")
       , notesViewFocus = NotesView()
       , notesViewFocusSVG = d3.select("#notes").append("svg")
+      , combineSeparateUI = CombineSeparateUI()
       , colorLegend = ColorLegend()
-      , defaultWork = "Jos2721-La_Bernardina"
+      , colorScale = d3.scale.category10()
+    ;
+
+    var defaultWork = "Jos2721-La_Bernardina"
       , hash = window.location.hash
       , work = hash ? hash.substr(1) : defaultWork
       , jsonURL = "http://josquin.stanford.edu/cgi-bin/jrp?a=proll-json&f=" + work
-      , colorScale = d3.scale.category10()
     ;
 
     colorLegend.colorScale(colorScale);

--- a/js/brushview.js
+++ b/js/brushview.js
@@ -6,42 +6,53 @@ function BrushView() {
     var svg
       , x
       , brush = d3.svg.brush()
+            .on("brush", brushed)
+            .on("brushend", brushed(true))
       , dispatch = d3.dispatch()
+      , height
     ;
 
     /*
     ** Main function Object
     */
     function my(sel) {
-        var height = sel.attr("height");
-
         svg = sel.selectAll(".brush")
             .data(["brush"])
           .enter().append("g")
             .attr("class", function(d) { return d; })
         ;
         svg
-            .call(brush.on("brush", brushed))
-          .selectAll("rect")
-            .attr("y", 0)
-            .attr("height", height - 1);
+            .call(brush)
         ;
     } // my() - Main Function Object
 
     /*
     ** Helper Functions
     */
-    function brushed() {
-        dispatch
-            .zoom({
-                extent: brush.empty() ? x.domain() : brush.extent()
-              })
-        ;
+    function brushed(ended) {
+        if(dispatch)
+            dispatch
+                .zoom({
+                      extent: brush.empty() ? x.domain() : brush.extent()
+                    , ended: ended || false
+                  })
+            ;
     } // brushed()
 
     /*
     ** API - Getters/Setters
     */
+    my.height = function(value) {
+        if(!arguments.length) return height;
+
+        height = value;
+        svg.selectAll("rect")
+          .attr("y", 0)
+          .attr("height", height - 1)
+        ;
+        return my;
+      } // my.height()
+    ;
     my.x = function(value) {
         if(!arguments.length) return x;
 

--- a/js/brushview.js
+++ b/js/brushview.js
@@ -26,19 +26,18 @@ function BrushView() {
             .attr("y", 0)
             .attr("height", height - 1);
         ;
+        dispatch = dispatch || d3.dispatch()
     } // my() - Main Function Object
 
     /*
     ** Helper Functions
     */
     function brushed() {
-        if(dispatch) {
-            dispatch
-                .zoom({
-                    extent: brush.empty() ? x.domain() : brush.extent()
-                  })
-            ;
-        }
+        dispatch
+            .zoom({
+                extent: brush.empty() ? x.domain() : brush.extent()
+              })
+        ;
     } // brushed()
 
     /*

--- a/js/brushview.js
+++ b/js/brushview.js
@@ -8,7 +8,7 @@ function BrushView() {
       , brush = d3.svg.brush()
             .on("brush", brushed)
             .on("brushend", brushed(true))
-      , dispatch = d3.dispatch()
+      , dispatch
       , height
     ;
 
@@ -29,12 +29,12 @@ function BrushView() {
     /*
     ** Helper Functions
     */
-    function brushed(ended) {
+    function brushed(stop) {
         if(dispatch)
             dispatch
                 .zoom({
                       extent: brush.empty() ? x.domain() : brush.extent()
-                    , ended: ended || false
+                    , ended: stop || false
                   })
             ;
     } // brushed()

--- a/js/brushview.js
+++ b/js/brushview.js
@@ -1,0 +1,64 @@
+function BrushView() {
+    /*
+    ** Private Variables
+    **   - These are exclusively used in this object only.
+    */
+    var svg
+      , x
+      , brush = d3.svg.brush()
+      , dispatch
+    ;
+
+    /*
+    ** Main function Object
+    */
+    function my(sel) {
+        var height = sel.attr("height");
+
+        svg = sel.selectAll(".brush")
+            .data(["brush"])
+          .enter().append("g")
+            .attr("class", function(d) { return d; })
+        ;
+        svg
+            .call(brush.on("brush", brushed))
+          .selectAll("rect")
+            .attr("y", 0)
+            .attr("height", height - 1);
+        ;
+    } // my() - Main Function Object
+
+    /*
+    ** Helper Functions
+    */
+    function brushed() {
+        if(dispatch) {
+            dispatch
+                .zoom({
+                    extent: brush.empty() ? x.domain() : brush.extent()
+                  })
+            ;
+        }
+    } // brushed()
+
+    /*
+    ** API - Getters/Setters
+    */
+    my.x = function(value) {
+        if(!arguments.length) return x;
+
+        x = value;
+        brush.x(x);
+
+        return my;
+      } // my.x()
+    ;
+    my.connect = function(value) {
+        if(!arguments.length) return dispatch;
+
+        dispatch = value;
+      } // my.connect()
+    ;
+    // This is ALWAYS the last thing returned
+    return my;
+} // brushableView()

--- a/js/brushview.js
+++ b/js/brushview.js
@@ -6,7 +6,7 @@ function BrushView() {
     var svg
       , x
       , brush = d3.svg.brush()
-      , dispatch
+      , dispatch = d3.dispatch()
     ;
 
     /*
@@ -26,7 +26,6 @@ function BrushView() {
             .attr("y", 0)
             .attr("height", height - 1);
         ;
-        dispatch = dispatch || d3.dispatch()
     } // my() - Main Function Object
 
     /*

--- a/js/combineSeparateUI.js
+++ b/js/combineSeparateUI.js
@@ -7,16 +7,18 @@ function CombineSeparateUI(){
     ;
 
     var labels = form.selectAll("label").data(data)
-      .enter().append("label")
-        .attr("class", "radio-inline")
+          .enter().append("label")
+            .attr("class", "radio-inline")
+      , inputs = labels.append("input")
+            .attr("type", "radio")
+            .attr("name", "combine-separate-group")
+      , spans = labels.append("span")
+            .text(function (d){ return " " + d + " "; })
     ;
-    labels.append("input")
-        .attr("type", "radio")
-        .attr("name", "combine-separate-group")
-    ;
-    labels.append("span")
-        .text(function (d){ return " " + d + " "; })
-    ;
+
+    inputs.on("click", function (e){
+        dispatch.separate(e == "Separate");
+    });
 
     function my() {
     } // my()

--- a/js/combineSeparateUI.js
+++ b/js/combineSeparateUI.js
@@ -1,34 +1,45 @@
 function CombineSeparateUI(){
-
-    var container = d3.select("#combine-separate-ui")
-      , form = container.append("form").attr("class", "form")
+    /*
+    ** Private Variables
+    */
+    var form
       , data = ["Combine", "Separate"]
       , dispatch
     ;
-
-    var labels = form.selectAll("label").data(data)
-          .enter().append("label")
-            .attr("class", "radio-inline")
-      , inputs = labels.append("input")
-            .attr("type", "radio")
-            .attr("name", "combine-separate-group")
-      , spans = labels.append("span")
-            .text(function (d){ return " " + d + " "; })
-    ;
-
-    inputs.on("click", function (e){
-        dispatch.separate(e == "Separate");
-    });
-
-    function my() {
-    } // my()
-
+    /*
+    ** Main Function Object
+    */
+    function my(sel) {
+        form = sel
+          .append("form")
+            .attr("class", "form")
+        ;
+        var labels = form.selectAll("label")
+                .data(data)
+              .enter().append("label")
+                .attr("class", "radio-inline")
+          , inputs = labels
+              .append("input")
+                .attr("type", "radio")
+                .attr("name", "combine-separate-group")
+                .property("checked", function(d, i) { return !i; })
+          , spans = labels
+              .append("span")
+                .text(function (d){ return " " + d + " "; })
+        ;
+        inputs.on("click", function (e){
+            dispatch.separate(e == "Separate");
+        });
+    } // my() - Main Function Object
+    /*
+    ** API (Getters/Setters)
+    */
     my.connect = function(value){
         if(!arguments.length) return dispatch;
         dispatch = value;
         return my;
       } // my.connect()
     ;
-
+    // ALWAYS return this last
     return my;
-}
+} // CombineSeparateUI()

--- a/js/combineSeparateUI.js
+++ b/js/combineSeparateUI.js
@@ -1,0 +1,32 @@
+function CombineSeparateUI(){
+
+    var container = d3.select("#combine-separate-ui")
+      , form = container.append("form").attr("class", "form")
+      , data = ["Combine", "Separate"]
+      , dispatch
+    ;
+
+    var labels = form.selectAll("label").data(data)
+      .enter().append("label")
+        .attr("class", "radio-inline")
+    ;
+    labels.append("input")
+        .attr("type", "radio")
+        .attr("name", "combine-separate-group")
+    ;
+    labels.append("span")
+        .text(function (d){ return " " + d + " "; })
+    ;
+
+    function my() {
+    } // my()
+
+    my.connect = function(value){
+        if(!arguments.length) return dispatch;
+        dispatch = value;
+        return my;
+      } // my.connect()
+    ;
+
+    return my;
+}

--- a/js/notesbook.js
+++ b/js/notesbook.js
@@ -5,10 +5,15 @@ function NotesBook() {
   var svg, data
     , width
     , height
-    , x = d3.scale.linear()
-    , y = d3.scale.ordinal()
+    , perspectives = ["full", "zoom"]
+    , scale = {
+          full: { x: d3.scale.linear(), y: d3.scale.linear() }
+        , zoom: { x: d3.scale.linear(), y: d3.scale.linear() }
+      }
+    , colorScale
     , dispatch
     , tooltip
+    , canvases = []
   ;
 
   /*
@@ -17,6 +22,19 @@ function NotesBook() {
   function my(selection) {
       svg = selection;
       data = svg.datum();
+      svg.selectAll(".notes-g")
+          .data(data)
+        .enter().append("g")
+          .each(function(d) {
+              canvases.push({
+                    key: d.key
+                  , canvas: NotesCanvas().colorScale(colorScale)
+              });
+              d3.select(this)
+                  .call(canvases[canvases.length - 1].canvas)
+              ;
+            })
+      ;
   } // my() - Main function object
 
   /*
@@ -37,15 +55,39 @@ function NotesBook() {
   ;
   my.width = function(value) {
       if(arguments.length === 0) return width;
+
       width = value;
+      perspectives.forEach(function(p) {
+          scale[p].x.range([0, width]);
+      });
+
       return my;
     } // my.width()
   ;
   my.height = function(value) {
       if(arguments.length === 0) return height;
+
       height = value;
+      perspectives.forEach(function(p) {
+          scale[p].y.range([height, 0]);
+      });
+
       return my;
     } // my.height()
+  ;
+  my.full = function(value) {
+      if(!arguments.length) return scale.full;
+
+      if(value[0])
+          scale.full.x.domain(value[0]);
+      if(value[1])
+          scale.full.y.domain(value[1]);
+
+      canvases.forEach(function(c) {
+          c.canvas.zoom(value);
+      });
+      return my;
+    } // my.full()
   ;
   my.connect = function(value) {
       if(!arguments.length) return dispatch;
@@ -54,9 +96,12 @@ function NotesBook() {
       return my;
     } // my.connect()
   ;
-  my.zoom = function(value) {
+  my.zoom = function(value, stop) {
       if(!arguments.length) return zoom;
 
+      canvases.forEach(function(c) {
+          c.canvas.zoom(value, stop);
+      });
       return my;
     } // my.zoom()
   ;

--- a/js/notesbook.js
+++ b/js/notesbook.js
@@ -2,7 +2,7 @@ function NotesBook() {
   /*
   ** Private Variables
   */
-  var svg
+  var svg, data
     , width
     , height
     , x = d3.scale.linear()
@@ -16,7 +16,7 @@ function NotesBook() {
   */
   function my(selection) {
       svg = selection;
-      console.log(svg.data())
+      data = svg.datum();
   } // my() - Main function object
 
   /*
@@ -29,19 +29,19 @@ function NotesBook() {
       return my;
     } // my.tooltip()
   ;
-  my.colorScale = function (value){
+  my.colorScale = function(value) {
       if(arguments.length === 0) return colorScale;
       colorScale = value;
       return my;
     } // my.colorScale()
   ;
-  my.width = function (value){
+  my.width = function(value) {
       if(arguments.length === 0) return width;
       width = value;
       return my;
     } // my.width()
   ;
-  my.height = function (value){
+  my.height = function(value) {
       if(arguments.length === 0) return height;
       height = value;
       return my;

--- a/js/notesbook.js
+++ b/js/notesbook.js
@@ -38,6 +38,19 @@ function NotesBook() {
   } // my() - Main function object
 
   /*
+  ** Helpeer Functions
+  */
+  function hilite(arg) {
+      var emphasize = arg && arg.emphasize;
+
+      canvases.forEach(function(c) {
+          c.canvas.hilite(arg);
+        })
+      ;
+  } // hilite()
+
+
+  /*
   ** API (Getter/Setter) Functions
   */
   my.tooltip = function(value) {
@@ -105,6 +118,16 @@ function NotesBook() {
       return my;
     } // my.zoom()
   ;
+  my.hilite = function(value) {
+      if(!arguments.length)
+          hilite();
+      else
+          hilite(value);
+
+      return my;
+    } // my.hilite()
+  ;
+
   // This is always the last thing returned
   return my;
 } // NotesBook()

--- a/js/notesbook.js
+++ b/js/notesbook.js
@@ -10,10 +10,12 @@ function NotesBook() {
           full: { x: d3.scale.linear(), y: d3.scale.linear() }
         , zoom: { x: d3.scale.linear(), y: d3.scale.linear() }
       }
+    , yScale = d3.scale.ordinal()
     , colorScale
     , dispatch
     , tooltip
     , canvases = []
+    , separate = false
   ;
 
   /*
@@ -35,10 +37,14 @@ function NotesBook() {
               ;
             })
       ;
+      yScale
+          .domain(data.map(function(d) { return d.key; }))
+          .rangeRoundBands([0, height])
+      ;
   } // my() - Main function object
 
   /*
-  ** Helpeer Functions
+  ** Helper Functions
   */
   function hilite(arg) {
       var emphasize = arg && arg.emphasize;
@@ -48,6 +54,23 @@ function NotesBook() {
         })
       ;
   } // hilite()
+
+  function update() {
+      if(separate) {
+          canvases.forEach(function(c) {
+              c.canvas.height(yScale.rangeBand());
+              c.canvas.transform([0, yScale(c.key)]);
+            })
+          ;
+      } else {
+          canvases.forEach(function(c) {
+              c.canvas.height(height);
+              c.canvas.transform([0, 0]);
+            })
+          ;
+
+      }
+  } // update()
 
 
   /*
@@ -84,6 +107,8 @@ function NotesBook() {
       perspectives.forEach(function(p) {
           scale[p].y.range([height, 0]);
       });
+
+      yScale.rangeRoundBands([height, 0]);
 
       return my;
     } // my.height()
@@ -127,6 +152,14 @@ function NotesBook() {
       return my;
     } // my.hilite()
   ;
+  my.separate = function(value) {
+      if(!arguments.length) return separate;
+
+      separate = value;
+      update();
+
+      return my;
+    } // my.separate()
 
   // This is always the last thing returned
   return my;

--- a/js/notesbook.js
+++ b/js/notesbook.js
@@ -1,0 +1,65 @@
+function NotesBook() {
+  /*
+  ** Private Variables
+  */
+  var svg
+    , width
+    , height
+    , x = d3.scale.linear()
+    , y = d3.scale.ordinal()
+    , dispatch
+    , tooltip
+  ;
+
+  /*
+  ** Main Function Object
+  */
+  function my(selection) {
+      svg = selection;
+      console.log(svg.data())
+  } // my() - Main function object
+
+  /*
+  ** API (Getter/Setter) Functions
+  */
+  my.tooltip = function(value) {
+      if(!arguments.length) return tooltip;
+
+      tooltip = value;
+      return my;
+    } // my.tooltip()
+  ;
+  my.colorScale = function (value){
+      if(arguments.length === 0) return colorScale;
+      colorScale = value;
+      return my;
+    } // my.colorScale()
+  ;
+  my.width = function (value){
+      if(arguments.length === 0) return width;
+      width = value;
+      return my;
+    } // my.width()
+  ;
+  my.height = function (value){
+      if(arguments.length === 0) return height;
+      height = value;
+      return my;
+    } // my.height()
+  ;
+  my.connect = function(value) {
+      if(!arguments.length) return dispatch;
+
+      dispatch = value;
+      return my;
+    } // my.connect()
+  ;
+  my.zoom = function(value) {
+      if(!arguments.length) return zoom;
+
+      return my;
+    } // my.zoom()
+  ;
+  // This is always the last thing returned
+  return my;
+} // NotesBook()

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -179,6 +179,16 @@ function NotesCanvas(){
         return my;
       } // my.hilite()
     ;
+    /*
+    ** API (Getter ONLY) Functions
+    */
+    my.noteHeight = function (){ return noteHeight; };
+    my.roundedCornerSize = function (){ return roundedCornerSize; };
+    my.x = function() { return x; };
+
+    /*
+    ** API (Setter ONLY) Functions
+    */
     my.separate = function (value){
         if(arguments.length === 0) return separate;
         separate = value;
@@ -196,13 +206,6 @@ function NotesCanvas(){
         return my;
       } // my.zoom()
     ;
-
-    /*
-    ** API (Getter ONLY) Functions
-    */
-    my.noteHeight = function (){ return noteHeight; };
-    my.roundedCornerSize = function (){ return roundedCornerSize; };
-    my.x = function() { return x; };
 
     // This is always the last thing returned
     return my;

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -1,4 +1,4 @@
-function NotesView(){
+function NotesCanvas(){
     /*
     ** Private Variables - only used inside this object
     */
@@ -172,4 +172,4 @@ function NotesView(){
       } // my.tipEnabled()
     ;
     return my;
-} // NotesView()
+} // NotesCanvas()

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -106,12 +106,6 @@ function NotesView(){
         ;
     } // hilite()
 
-    // Brush callback
-    function brushed(){
-        dispatch.zoom({
-          extent: brush.empty() ? x.domain() : brush.extent()
-        });
-    }
     /*
     ** API (Getter/Setter) Functions
     */

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -163,6 +163,7 @@ function NotesCanvas(){
 
         height = value;
         perspectives.forEach(function(p) { scale[p].y.range([height, 0]); });
+
         setHeights();
 
         return my;
@@ -192,7 +193,24 @@ function NotesCanvas(){
         return my;
       } // my.hilite()
     ;
-
+    my.transform = function(value) {
+        if(arguments.length)
+        svg
+          .transition()
+            .attr("transform", "translate(" + value[0] + "," + value[1] + ")")
+          .selectAll("rect.note")
+            .attr("x", function(d) { return scale.zoom.x(d.time); })
+            .attr("y", function(d) { return scale.zoom.y(d.pitch); })
+            .attr("width", function(d) { return scale.zoom.x(d.time + d.duration) - scale.zoom.x(d.time); })
+            .attr("height", noteHeight)
+            .attr("fill", function(d) { return colorScale(d.voice); })
+            .attr("stroke", function(d) { return colorScale(d.voice); })
+            .attr("rx", roundedCornerSize)
+            .attr("ry", roundedCornerSize)
+        ;
+        return my;
+      } // my.transform()
+    ;
     /*
     ** API (Getter ONLY) Functions
     */

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -109,6 +109,31 @@ function NotesCanvas(){
         ;
     } // update()
 
+    function describe() {
+        /*
+        // Filter the notes based on the selected time interval.
+        var filteredData = data.notes
+            .filter(function (d){
+                return d.time > extent[0] && d.time < extent[1];
+              })
+        ;
+        // Update the pitch names text.
+        var pitchNames = filteredData
+            .map(function (d){ return d.pitchName; })
+        ;
+        d3.select("#note-names-string")
+            .text(pitchNames.join(", "))
+        ;
+        // Update the note durations text.
+        pitchNames = filteredData
+            .map(function (d){ return d.duration; })
+        ;
+        d3.select("#note-durations-string")
+            .text(pitchNames.join(", "))
+        ;
+        */
+    } // describe()
+
     /*
     ** API (Getter/Setter) Functions
     */
@@ -160,12 +185,14 @@ function NotesCanvas(){
         return my;
       } // my.separate()
     ;
-    my.zoom = function(value) {
+    my.zoom = function(value, ended) {
         // Set the xdomain of notes in the zoomed in region and update
         //  -- if value is epty, the zoom is reset to the entire domain (xorig)
         x.domain(arguments.length ? value : xorig.domain());
         update();
 
+        if(ended)
+            describe();
         return my;
       } // my.zoom()
     ;

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -59,9 +59,6 @@ function NotesCanvas(){
         rects
           .enter().append("rect")
             .attr("class", "note")
-            .classed("subdued", function(d) {
-                return emphasize && d.voice !== emphasize;
-              })
         ;
         rects.exit().remove();
         rects

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -2,7 +2,7 @@ function NotesCanvas(){
     /*
     ** Private Variables - only used inside this object
     */
-    var svg
+    var svg, data, name
       , width = 900
       , height = 500
       , margin = { top: 10, bottom: 20, left: 10, right: 10 }
@@ -21,21 +21,18 @@ function NotesCanvas(){
     ** Main Function Object
     */
     function my(selection){
-        var data = selection.datum();
-        svg = selection
-            .attr("height", height)
-            .attr("width", width)
-        ;
-        svg.selectAll("g")
-            .data(["notes-g"])
+        data = selection.datum();
+        name = data.key;
+        svg = selection.selectAll("." + name + ".notes-g")
+              .data([name])
             .enter()
               .append("g")
-              .attr("class", function (d){ return d; })
+              .attr("class", "notes-g " + name)
         ;
         xorig
             .domain([
-                  d3.min(data, function(d) { return d.time; })
-                , d3.max(data, function(d) { return d.time + d.duration; })
+                  d3.min(data.values, function(d) { return d.time; })
+                , d3.max(data.values, function(d) { return d.time + d.duration; })
               ])
             .range([0, width - 1]);
         ;
@@ -45,16 +42,15 @@ function NotesCanvas(){
         ;
         y
             .domain([
-                  d3.min(data, function(d) { return d.pitch - 1; })
-                , d3.max(data, function(d) { return d.pitch; })
+                  d3.min(data.values, function(d) { return d.pitch - 1; })
+                , d3.max(data.values, function(d) { return d.pitch; })
               ])
             .range([height, 0])
         ;
         noteHeight = height / (y.domain()[1] - y.domain()[0]);
         roundedCornerSize = noteHeight / 2;
 
-        var notesG = svg.select(".notes-g")
-          , rects = notesG.selectAll("rect").data(data)
+        var rects = svg.selectAll("rect").data(data.values)
         ;
         rects
           .enter().append("rect")

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -24,6 +24,7 @@ function NotesCanvas(){
     ** Main Function Object
     */
     function my(selection){
+        var data = selection.datum();
         svg = selection
             .attr("height", height)
             .attr("width", width)
@@ -37,60 +38,58 @@ function NotesCanvas(){
               .append("g")
               .attr("class", function (d){ return d; })
         ;
-        svg.each(function(data) {
-            if(xDomain){
-                x.domain(xDomain);
-            } else {
-                x.domain([
-                      d3.min(data, function(d) { return d.time; })
-                    , d3.max(data, function(d) { return d.time + d.duration; })
-                  ])
-                ;
-            }
-            x.range([0, width - 1]);
+        if(xDomain){
+            x.domain(xDomain);
+        } else {
+            x.domain([
+                  d3.min(data, function(d) { return d.time; })
+                , d3.max(data, function(d) { return d.time + d.duration; })
+              ])
+            ;
+        }
+        x.range([0, width - 1]);
 
-            y
-                .domain([
-                      d3.min(data, function(d) { return d.pitch - 1; })
-                    , d3.max(data, function(d) { return d.pitch; })
-                  ])
-                .range([height, 0])
-            ;
-            noteHeight = height / (y.domain()[1] - y.domain()[0])
-            roundedCornerSize = noteHeight / 2
+        y
+            .domain([
+                  d3.min(data, function(d) { return d.pitch - 1; })
+                , d3.max(data, function(d) { return d.pitch; })
+              ])
+            .range([height, 0])
+        ;
+        noteHeight = height / (y.domain()[1] - y.domain()[0])
+        roundedCornerSize = noteHeight / 2
 
-            var notesG = svg.select(".notes-g")
-              , rects = notesG.selectAll("rect").data(data)
-            ;
+        var notesG = svg.select(".notes-g")
+          , rects = notesG.selectAll("rect").data(data)
+        ;
+        rects
+          .enter().append("rect")
+            .attr("class", "note")
+            .classed("subdued", function(d) {
+                return emphasize && d.voice !== emphasize;
+              })
+        ;
+        rects.exit().remove();
+        rects
+            .classed("subdued", function(d) {
+                return emphasize && d.voice !== emphasize;
+              })
+          .transition()
+            .attr("x", function(d) { return x(d.time); })
+            .attr("y", function(d) { return y(d.pitch); })
+            .attr("width", function(d) { return x(d.time + d.duration) - x(d.time); })
+            .attr("height", noteHeight)
+            .attr("fill", function(d) { return colorScale(d.voice); })
+            .attr("stroke", function(d) { return colorScale(d.voice); })
+            .attr("rx", roundedCornerSize)
+            .attr("ry", roundedCornerSize)
+        ;
+        if(tooltip){
             rects
-              .enter().append("rect")
-                .attr("class", "note")
-                .classed("subdued", function(d) {
-                    return emphasize && d.voice !== emphasize;
-                  })
+                .on("mouseover", tip.show)
+                .on("mouseout", tip.hide)
             ;
-            rects.exit().remove();
-            rects
-                .classed("subdued", function(d) {
-                    return emphasize && d.voice !== emphasize;
-                  })
-              .transition()
-                .attr("x", function(d) { return x(d.time); })
-                .attr("y", function(d) { return y(d.pitch); })
-                .attr("width", function(d) { return x(d.time + d.duration) - x(d.time); })
-                .attr("height", noteHeight)
-                .attr("fill", function(d) { return colorScale(d.voice); })
-                .attr("stroke", function(d) { return colorScale(d.voice); })
-                .attr("rx", roundedCornerSize)
-                .attr("ry", roundedCornerSize)
-            ;
-            if(tooltip){
-                rects
-                    .on("mouseover", tip.show)
-                    .on("mouseout", tip.hide)
-                ;
-            }
-        }); // svg.each()
+        }
     } // my()
 
     /*

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -110,20 +110,20 @@ function NotesCanvas(){
         if(arguments.length === 0) return colorScale;
         colorScale = value;
         return my;
-    };
-
+      } // my.colorScale()
+    ;
     my.width = function (value){
         if(arguments.length === 0) return width;
         width = value;
         return my;
-    };
-
+      } // my.width()
+    ;
     my.height = function (value){
         if(arguments.length === 0) return height;
         height = value;
         return my;
-    };
-
+      } // my.height()
+    ;
     my.noteHeight = function (){ return noteHeight; };
     my.roundedCornerSize = function (){ return roundedCornerSize; };
 

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -9,6 +9,8 @@ function NotesCanvas(){
       , x = d3.scale.linear()
       , xorig = d3.scale.linear()
       , y = d3.scale.linear()
+      , perspectives = ["full", "data", "zoom"]
+      , scale = {}
       , tooltip
       , colorScale
       , noteHeight
@@ -29,6 +31,10 @@ function NotesCanvas(){
               .append("g")
               .attr("class", "notes-g " + name)
         ;
+        perspectives.forEach(function(p) {
+            scale[p].x = d3.scale.linear().range([0, width]);
+            scale[p].y = d3.scale.linear().range([height,0]);
+        });
         xorig
             .domain([
                   d3.min(data.values, function(d) { return d.time; })

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -1,0 +1,175 @@
+function NotesView(){
+    /*
+    ** Private Variables - only used inside this object
+    */
+    var svg
+      , width = 900
+      , height = 500
+      , margin = { top: 10, bottom: 20, left: 10, right: 10 }
+      , x = d3.scale.linear()
+      , yPitch = d3.scale.linear()
+      , tooltip
+      , colorScale
+      , noteHeight
+      , roundedCornerSize
+      , dispatch
+      , emphasize
+      , separate
+      // This is a fixed x domain set from outside,
+      // it overrides the domain computed from the data.
+      // This is set on the focus view based on the brush of the context view.
+      , xDomain
+    ;
+    /*
+    ** Main Function Object
+    */
+    function my(selection){
+        svg = selection
+            .attr("height", height)
+            .attr("width", width)
+        ;
+        if(tooltip)
+            svg.call(tooltip)
+        ;
+        svg.selectAll("g")
+            .data(["notes-g"])
+            .enter()
+              .append("g")
+              .attr("class", function (d){ return d; })
+        ;
+        svg.each(function(data) {
+            if(xDomain){
+                x.domain(xDomain);
+            } else {
+                x.domain([
+                      d3.min(data, function(d) { return d.time; })
+                    , d3.max(data, function(d) { return d.time + d.duration; })
+                  ])
+                ;
+            }
+            x.range([0, width - 1]);
+
+            yPitch
+                .domain([
+                      d3.min(data, function(d) { return d.pitch - 1; })
+                    , d3.max(data, function(d) { return d.pitch; })
+                  ])
+                .range([height, 0])
+            ;
+            noteHeight = height / (yPitch.domain()[1] - yPitch.domain()[0])
+            roundedCornerSize = noteHeight / 2
+
+            var notesG = svg.select(".notes-g")
+              , rects = notesG.selectAll("rect").data(data)
+            ;
+            rects
+              .enter().append("rect")
+                .attr("class", "note")
+                .classed("subdued", function(d) {
+                    return emphasize && d.voice !== emphasize;
+                  })
+            ;
+            rects.exit().remove();
+            rects
+                .classed("subdued", function(d) {
+                    return emphasize && d.voice !== emphasize;
+                  })
+              .transition()
+                .attr("x", function(d) { return x(d.time); })
+                .attr("y", function(d) { return yPitch(d.pitch); })
+                .attr("width", function(d) { return x(d.time + d.duration) - x(d.time); })
+                .attr("height", noteHeight)
+                .attr("fill", function(d) { return colorScale(d.voice); })
+                .attr("stroke", function(d) { return colorScale(d.voice); })
+                .attr("rx", roundedCornerSize)
+                .attr("ry", roundedCornerSize)
+            ;
+            if(tooltip){
+                rects
+                    .on("mouseover", tip.show)
+                    .on("mouseout", tip.hide)
+                ;
+            }
+        }); // svg.each()
+    } // my()
+
+    /*
+    ** Helper Functions
+    */
+    function hilite(arg) {
+        emphasize = arg.emphasize;
+
+        svg.selectAll("rect.note")
+            .classed("subdued", function(d) {
+                return emphasize && d.voice !== emphasize;
+              })
+        ;
+    } // hilite()
+
+    // Brush callback
+    function brushed(){
+        dispatch.zoom({
+          extent: brush.empty() ? x.domain() : brush.extent()
+        });
+    }
+    /*
+    ** API (Getter/Setter) Functions
+    */
+    my.colorScale = function (value){
+        if(arguments.length === 0) return colorScale;
+        colorScale = value;
+        return my;
+    };
+
+    my.width = function (value){
+        if(arguments.length === 0) return width;
+        width = value;
+        return my;
+    };
+
+    my.height = function (value){
+        if(arguments.length === 0) return height;
+        height = value;
+        return my;
+    };
+
+    my.noteHeight = function (){ return noteHeight; };
+    my.roundedCornerSize = function (){ return roundedCornerSize; };
+
+    my.xDomain = function(value) {
+        if(!arguments.length) return xDomain;
+
+        xDomain = value;
+        return my;
+      } // my.xDomain()
+    ;
+    my.x = function() {
+        return x; // GETTER ONLY
+      } // my.x()
+    ;
+    my.tooltip = function(value) {
+        if(!arguments.length === 0) return tooltip;
+        tooltip = value
+            .html(function(d) { return d.pitchName; })
+        ;
+        return my;
+      } // my.tooltip()
+    ;
+    my.connect = function(value){
+        if(!arguments.length) return dispatch;
+
+        dispatch = value
+            .on("hilite.notesview" + name, hilite) // listen for appropriate events
+        ;
+
+        return my;
+      } // my.connect()
+    ;
+    my.separate = function (value){
+        if(arguments.length === 0) return separate;
+        separate = value;
+        return my;
+      } // my.tipEnabled()
+    ;
+    return my;
+} // NotesView()

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -103,12 +103,6 @@ function NotesCanvas(){
         ;
     } // hilite()
 
-    // Brush callback
-    function brushed(){
-        dispatch.zoom({
-          extent: brush.empty() ? x.domain() : brush.extent()
-        });
-    }
     /*
     ** API (Getter/Setter) Functions
     */

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -94,7 +94,7 @@ function NotesCanvas(){
     ** Helper Functions
     */
     function hilite(arg) {
-        emphasize = arg.emphasize;
+        emphasize = arg && arg.emphasize;
 
         svg.selectAll("rect.note")
             .classed("subdued", function(d) {
@@ -142,12 +142,18 @@ function NotesCanvas(){
     my.connect = function(value){
         if(!arguments.length) return dispatch;
 
-        dispatch = value
-            .on("hilite.notesview" + name, hilite) // listen for appropriate events
-        ;
-
+        dispatch = value;
         return my;
       } // my.connect()
+    ;
+    my.hilite = function(value) {
+        if(!arguments.length)
+            hilite(); // un-highlight
+        else
+            hilite(value);
+
+        return my;
+      } // my.hilite()
     ;
     my.separate = function (value){
         if(arguments.length === 0) return separate;

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -53,8 +53,8 @@ function NotesCanvas(){
               ])
             .range([height, 0])
         ;
-        noteHeight = height / (y.domain()[1] - y.domain()[0])
-        roundedCornerSize = noteHeight / 2
+        noteHeight = height / (y.domain()[1] - y.domain()[0]);
+        roundedCornerSize = noteHeight / 2;
 
         var notesG = svg.select(".notes-g")
           , rects = notesG.selectAll("rect").data(data)

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -98,9 +98,9 @@ function NotesCanvas(){
 
     function update() {
         svg.selectAll("rect.note")
-            .attr("x", function(d) { return x(d.time); })
-            .attr("y", function(d) { return y(d.pitch); })
-            .attr("width", function(d) { return x(d.time + d.duration) - x(d.time); })
+            .attr("x", function(d) { return scale.zoom.x(d.time); })
+            .attr("y", function(d) { return scale.zoom.y(d.pitch); })
+            .attr("width", function(d) { return scale.zoom.x(d.time + d.duration) - scale.zoom.x(d.time); })
             .attr("height", noteHeight)
             .attr("fill", function(d) { return colorScale(d.voice); })
             .attr("stroke", function(d) { return colorScale(d.voice); })

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -124,19 +124,12 @@ function NotesCanvas(){
         return my;
       } // my.height()
     ;
-    my.noteHeight = function (){ return noteHeight; };
-    my.roundedCornerSize = function (){ return roundedCornerSize; };
-
     my.xDomain = function(value) {
         if(!arguments.length) return xDomain;
 
         xDomain = value;
         return my;
       } // my.xDomain()
-    ;
-    my.x = function() {
-        return x; // GETTER ONLY
-      } // my.x()
     ;
     my.tooltip = function(value) {
         if(!arguments.length === 0) return tooltip;
@@ -162,5 +155,14 @@ function NotesCanvas(){
         return my;
       } // my.separate()
     ;
+
+    /*
+    ** API (Getter ONLY) Functions
+    */
+    my.noteHeight = function (){ return noteHeight; };
+    my.roundedCornerSize = function (){ return roundedCornerSize; };
+    my.x = function() { return x; };
+
+    // This is always the last thing returned
     return my;
 } // NotesCanvas()

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -29,9 +29,6 @@ function NotesCanvas(){
             .attr("height", height)
             .attr("width", width)
         ;
-        if(tooltip)
-            svg.call(tooltip)
-        ;
         svg.selectAll("g")
             .data(["notes-g"])
             .enter()
@@ -85,6 +82,7 @@ function NotesCanvas(){
             .attr("ry", roundedCornerSize)
         ;
         if(tooltip){
+            svg.call(tooltip);
             rects
                 .on("mouseover", tip.show)
                 .on("mouseout", tip.hide)

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -44,7 +44,6 @@ function NotesCanvas(){
               ])
             .range([0, width - 1]);
         ;
-        console.log(data, scale.data.x.domain())
         scale.data.y
             .domain([
                   d3.min(data.values, function(d) { return d.pitch - 1; })

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -160,7 +160,7 @@ function NotesCanvas(){
         if(arguments.length === 0) return separate;
         separate = value;
         return my;
-      } // my.tipEnabled()
+      } // my.separate()
     ;
     return my;
 } // NotesCanvas()

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -7,8 +7,7 @@ function NotesCanvas(){
       , height = 500
       , margin = { top: 10, bottom: 20, left: 10, right: 10 }
       , scale = {
-            full: { x: d3.scale.linear(), y: d3.scale.linear() }
-          , data: { x: d3.scale.linear(), y: d3.scale.linear() }
+          data: { x: d3.scale.linear(), y: d3.scale.linear() }
           , zoom: { x: d3.scale.linear(), y: d3.scale.linear() }
         }
       , perspectives = d3.keys(scale)
@@ -145,6 +144,7 @@ function NotesCanvas(){
     */
     my.colorScale = function (value){
         if(arguments.length === 0) return colorScale;
+
         colorScale = value;
         return my;
       } // my.colorScale()
@@ -210,28 +210,27 @@ function NotesCanvas(){
         return my;
       } // my.separate()
     ;
-    my.zoom = function(value, ended) {
+    my.zoom = function(value, stop) {
         // Set the xdomain of notes in the zoomed in region and update
         //  -- if value is epty, the zoom is reset to the entire domain (xorig)
-        scale.zoom.x.domain(arguments.length ? value : scale.x.data.domain());
+        if(!arguments.length) {
+            scale.zoom.x.domain(scale.x.data.domain());
+            scale.zoom.y.domain(scale.y.data.domain());
+        } else {
+            if(value[1][1]) {
+                scale.zoom.x.domain(value[0]);
+                scale.zoom.y.domain(value[1]);
+            } else {
+                scale.zoom.x.domain(value)
+            }
+        }
         update();
 
-        if(ended)
+        if(stop)
             describe();
         return my;
       } // my.zoom()
     ;
-    my.full = function(value) {
-        if(!arguments.length) return scale.full.x;
-
-        scale.full.x.domain(value[0]);
-        if(value[1])
-            scale.full.y.domain(value[1]);
-
-        return my;
-      } // my.full()
-    ;
-
     // This is always the last thing returned
     return my;
 } // NotesCanvas()

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -26,12 +26,8 @@ function NotesCanvas(){
     function my(selection){
         data = selection.datum();
         name = data.key;
-        svg = selection.selectAll("." + name + ".notes-g")
-              .data([name])
-            .enter()
-              .append("g")
-              .attr("class", "notes-g " + name)
-        ;
+        svg = selection.attr("class", "notes-g " + name);
+
         perspectives.forEach(function(p) {
             scale[p].x.range([0, width]);
             scale[p].y.range([height,0]);

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -35,15 +35,15 @@ function NotesCanvas(){
         ;
         scale.data.x
             .domain([
-                  d3.min(data.values, function(d) { return d.time; })
-                , d3.max(data.values, function(d) { return d.time + d.duration; })
+                  d3.min(data.value, function(d) { return d.time; })
+                , d3.max(data.value, function(d) { return d.time + d.duration; })
               ])
             .range([0, width - 1]);
         ;
         scale.data.y
             .domain([
-                  d3.min(data.values, function(d) { return d.pitch - 1; })
-                , d3.max(data.values, function(d) { return d.pitch; })
+                  d3.min(data.value, function(d) { return d.pitch - 1; })
+                , d3.max(data.value, function(d) { return d.pitch; })
               ])
             .range([height, 0])
         ;
@@ -56,7 +56,7 @@ function NotesCanvas(){
             .range(scale.data.y.range())
         ;
         setHeights();
-        var rects = svg.selectAll("rect").data(data.values);
+        var rects = svg.selectAll("rect").data(data.value);
         rects
           .enter().append("rect")
             .attr("class", "note")

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -44,6 +44,7 @@ function NotesCanvas(){
               ])
             .range([0, width - 1]);
         ;
+        console.log(data, scale.data.x.domain())
         scale.data.y
             .domain([
                   d3.min(data.values, function(d) { return d.pitch - 1; })
@@ -59,9 +60,7 @@ function NotesCanvas(){
             .domain(scale.data.y.domain())
             .range(scale.data.y.range())
         ;
-        noteHeight = height / (scale.zoom.y.domain()[1] - scale.zoom.y.domain()[0]);
-        roundedCornerSize = noteHeight / 2;
-
+        setHeights();
         var rects = svg.selectAll("rect").data(data.values);
         rects
           .enter().append("rect")
@@ -115,6 +114,11 @@ function NotesCanvas(){
         ;
     } // update()
 
+    function setHeights() {
+        noteHeight = height / (scale.zoom.y.domain()[1] - scale.zoom.y.domain()[0]);
+        roundedCornerSize = noteHeight / 2;
+    } // setHeights()
+
     function describe() {
         /*
         // Filter the notes based on the selected time interval.
@@ -163,8 +167,7 @@ function NotesCanvas(){
 
         height = value;
         perspectives.forEach(function(p) { scale[p].y.range([height, 0]); });
-        noteHeight = height / (scale.zoom.y.domain()[1] - scale.zoom.y.domain()[0]);
-        roundedCornerSize = noteHeight / 2;
+        setHeights();
 
         return my;
       } // my.height()
@@ -222,7 +225,7 @@ function NotesCanvas(){
         return my;
       } // my.zoom()
     ;
-    my.context = function(value) {
+    my.full = function(value) {
         if(!arguments.length) return scale.full.x;
 
         scale.full.x.domain(value[0]);
@@ -230,7 +233,7 @@ function NotesCanvas(){
             scale.full.y.domain(value[1]);
 
         return my;
-      } // my.contextX()
+      } // my.full()
     ;
 
     // This is always the last thing returned

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -97,6 +97,7 @@ function NotesCanvas(){
     } // hilite()
 
     function update() {
+        setHeights();
         svg.selectAll("rect.note")
             .attr("x", function(d) { return scale.zoom.x(d.time); })
             .attr("y", function(d) { return scale.zoom.y(d.pitch); })

--- a/js/notescanvas.js
+++ b/js/notescanvas.js
@@ -7,7 +7,7 @@ function NotesCanvas(){
       , height = 500
       , margin = { top: 10, bottom: 20, left: 10, right: 10 }
       , x = d3.scale.linear()
-      , yPitch = d3.scale.linear()
+      , y = d3.scale.linear()
       , tooltip
       , colorScale
       , noteHeight
@@ -49,14 +49,14 @@ function NotesCanvas(){
             }
             x.range([0, width - 1]);
 
-            yPitch
+            y
                 .domain([
                       d3.min(data, function(d) { return d.pitch - 1; })
                     , d3.max(data, function(d) { return d.pitch; })
                   ])
                 .range([height, 0])
             ;
-            noteHeight = height / (yPitch.domain()[1] - yPitch.domain()[0])
+            noteHeight = height / (y.domain()[1] - y.domain()[0])
             roundedCornerSize = noteHeight / 2
 
             var notesG = svg.select(".notes-g")
@@ -76,7 +76,7 @@ function NotesCanvas(){
                   })
               .transition()
                 .attr("x", function(d) { return x(d.time); })
-                .attr("y", function(d) { return yPitch(d.pitch); })
+                .attr("y", function(d) { return y(d.pitch); })
                 .attr("width", function(d) { return x(d.time + d.duration) - x(d.time); })
                 .attr("height", noteHeight)
                 .attr("fill", function(d) { return colorScale(d.voice); })

--- a/js/notesview.js
+++ b/js/notesview.js
@@ -75,7 +75,7 @@ function NotesView(){
 
             if(separate){
                 yPitch.range([height / yVoice.domain().length, 0]);
-                yVoice.rangeBands([height, 0]);
+                yVoice.rangeBands([0, height]);
             } else {
                 yPitch.range([height, 0]);
                 yVoice.rangeBands([0, 0]);

--- a/js/notesview.js
+++ b/js/notesview.js
@@ -13,21 +13,18 @@ function NotesView(){
           .x(x)
           .on("brush", brushed)
       , brushEnabled = false
-      , tipEnabled = false
       , colorScale
       , noteHeight
       , roundedCornerSize
       , dispatch
       , emphasize
       , separate
+      , tooltip
 
       // This is a fixed x domain set from outside,
       // it overrides the domain computed from the data.
       // This is set on the focus view based on the brush of the context view.
       , xDomain
-      , tip = d3.tip()
-          .attr("class", "d3-tip")
-          .html(function(d) { return d.pitchName; });
     ;
     /*
     ** Main Function Object
@@ -43,8 +40,8 @@ function NotesView(){
               .append("g")
               .attr("class", function (d){ return d; })
         ;
-        if(tipEnabled)
-            svg.call(tip)
+        if(tooltip)
+            svg.call(tooltip)
         ;
         var notesG = svg.select(".notes-g")
           , brushG = svg.select(".brush")
@@ -122,7 +119,7 @@ function NotesView(){
                     .attr("height", height - 1);
             }
 
-            if(tipEnabled){
+            if(tooltip){
                 rects
                     .on("mouseover", tip.show)
                     .on("mouseout", tip.hide)
@@ -182,13 +179,15 @@ function NotesView(){
 
     my.xDomain = function (value){
         xDomain = value;
-    };
-
-    my.tipEnabled = function (value){
-        if(arguments.length === 0) return tipEnabled;
-        tipEnabled = value;
+      } // my.xDomain()
+    ;
+    my.tooltip = function(value) {
+        if(!arguments.length === 0) return tooltip;
+        tooltip = value
+            .html(function(d) { return d.pitchName; })
+        ;
         return my;
-      } // my.tipEnabled()
+      } // my.tooltip()
     ;
     my.connect = function(value){
         if(!arguments.length) return dispatch;

--- a/js/notesview.js
+++ b/js/notesview.js
@@ -93,6 +93,10 @@ function NotesView(){
             ;
             rects.exit().remove();
             rects
+                .classed("subdued", function(d) {
+                    return emphasize && d.voice !== emphasize;
+                  })
+              .transition()
                 .attr("x", function(d) { return x(d.time); })
                 .attr("y", function(d) { return yPitch(d.pitch) + yVoice(d.voice); })
                 .attr("width", function(d) { return x(d.time + d.duration) - x(d.time); })
@@ -101,9 +105,6 @@ function NotesView(){
                 .attr("stroke", function(d) { return colorScale(d.voice); })
                 .attr("rx", roundedCornerSize)
                 .attr("ry", roundedCornerSize)
-                .classed("subdued", function(d) {
-                    return emphasize && d.voice !== emphasize;
-                  })
             ;
 
             if(brushEnabled){

--- a/js/notesview.js
+++ b/js/notesview.js
@@ -1,4 +1,7 @@
 function NotesView(){
+    /*
+    ** Private Variables - only used inside this object
+    */
     var svg
       , width = 900
       , height = 500
@@ -26,13 +29,9 @@ function NotesView(){
           .attr("class", "d3-tip")
           .html(function(d) { return d.pitchName; });
     ;
-
-    function brushed(){
-      dispatch.zoom({
-        extent: brush.empty() ? x.domain() : brush.extent()
-      });
-    }
-
+    /*
+    ** Main Function Object
+    */
     function my(selection){
         svg = selection
             .attr("height", height)
@@ -144,6 +143,12 @@ function NotesView(){
         ;
     } // hilite()
 
+    // Brush callback
+    function brushed(){
+      dispatch.zoom({
+        extent: brush.empty() ? x.domain() : brush.extent()
+      });
+    }
     /*
     ** API (Getter/Setter) Functions
     */

--- a/js/notesview.js
+++ b/js/notesview.js
@@ -75,10 +75,10 @@ function NotesView(){
 
             if(separate){
                 yPitch.range([height / yVoice.domain().length, 0]);
-                yVoice.rangePoints([height / yVoice.domain().length, 0]);
+                yVoice.rangeBands([height, 0]);
             } else {
                 yPitch.range([height, 0]);
-                yVoice.rangePoints([0, 0]);
+                yVoice.rangeBands([0, 0]);
             }
 
             noteHeight = height / (yPitch.domain()[1] - yPitch.domain()[0])


### PR DESCRIPTION
Basing from Curran's combine-separate branch, this set of changes:
1. Refactor the function objects:
   - NotesView is now NotesCanvas for rendering the notes
   - NotesBook powers the "focus" view by puttng NotesCanvases together and translating as necessary
   - BrushView adds a brush on top of a NotesCanvas
2. The NotesCanvas now has an update() function so that it is not re-rendered on every event, but rather, when the domain is adjusted, it updates smoothly.
   - This takes care of the jumpy brush/zoom behaviour
   - Zooming is done by specifying a subdomain on x
3. Combine/Separate was shoe-horned into the old NotesView.  It is now a function of the NotesBook.  The individual NotesCanvas objects don't need to know where they're drawing, they just need a <g> element into which to draw.  The NotesBook figures out where to place the drawings with respect to each other.
4. The brush canvas is now only a navigator. It allows you to zoom and pan but does not show hilites and separations.  The focus canvas is the one that reflects those interactions (hiliting and combining/separating).
