### PR TITLE
Autozoom

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,7 +15,6 @@ header {
     font-family: 'BravuraText';
     font-size: xx-large;
 }
-
 #legend li {
     cursor: pointer;
 }
@@ -44,6 +43,9 @@ rect.extreme {
     fill-opacity: .08;
     stroke-opacity: .2;
     shape-rendering: crispEdges;
+}
+.brush .selection {
+    stroke: darkgrey;
 }
 path.domain {
     fill: none;

--- a/js/baton.js
+++ b/js/baton.js
@@ -12,6 +12,8 @@ var width = 960
   , colorLegend = ColorLegend()
       .div(d3.select("div#legend"))
   , colorScale = d3.scaleOrdinal(d3.schemeCategory10)
+  , lifeSize = 10 // screen width of 1 duration
+  , lifeScale = d3.scaleLinear()
 ;
 var defaultWork = "Jos2721-La_Bernardina"
   , hash = getQueryVariables()
@@ -50,8 +52,14 @@ function parseJSON(proll) {
 } // parseJSON()
 
 function chartify(data) {
-    var signal = d3.dispatch("hilite", "zoom", "separate", "selected", "extremes");
-
+    var signal = d3.dispatch(
+              "hilite"
+            , "zoom"
+            , "separate"
+            , "selected"
+            , "extremes"
+          )
+    ;
     combineSeparateUI.connect(signal);
     extremeNotesUI.connect(signal);
 
@@ -95,8 +103,17 @@ function chartify(data) {
         , y: d3.range(data.minpitch.b7, data.maxpitch.b7)
       }
     ;
-    notesNav.full(full);
+//    notesNav.full(full);
     notesBook.full(full);
+
+    // Lifesize of this piece
+    lifeScale
+        .range([0, lifeSize * data.scorelength[0]])
+        .domain([0, data.scorelength[0]])
+    ;
+    // Domain window corresponding to the size of the canvas
+    var nbwidth = lifeScale.invert(notesBook.width());
+    notesNav.extent([0, nbwidth])
 
     signal
         .on("zoom",     notesBook.zoom)

--- a/js/notesnav.js
+++ b/js/notesnav.js
@@ -55,6 +55,7 @@ function NotesNav() {
         ;
         brush.selection = g.select(".brush")
             .call(brush.widget)
+            brush.selection.call(brush.widget.move, canvas.widget.x().range())
         ;
         brush.selection.selectAll("rect")
             .attr("y", 0)
@@ -152,6 +153,17 @@ function NotesNav() {
 
         return my;
       } // my.full()
+    ;
+    my.extent = function(value) {
+        if(!value) return;
+        var t = d3.transition()
+          , extent = value.map(canvas.widget.x())
+        ;
+        brush.selection
+          .transition(t)
+            .call(brush.widget.move, extent)
+        ;
+      } // my.extent()
     ;
     my.svg = function (value){
         if(arguments.length === 0) return svg;


### PR DESCRIPTION
Rather than show the full domain in both views, this set of changes essentially treats the "context" view as a window above a large SVG. So the size of that SVG is set to be 10 pixels per duration.  Thus, the focus view gets pre-zoomed, and as a bonus the brush gets pre-added.

There is also an initial transition zooming from the full domain to the windowed domain.

The behavior of empty brush is undefined and error prone at the moment.  My thinking is that an empty click should create the "default" brush centered at the click.
