### PR TITLE
New bar numbers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -64,10 +64,6 @@ svg {
 path.domain {
     display: none;
 }
-.barlines .tick text {
-    display: none;
-    fill: none;
-}
 .terminal {
     stroke: black;
     stroke-width: 2;

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -118,7 +118,7 @@ function NotesBook() {
           .call(renderBarlines)
       ;
       barlines.selectAll(".tick")
-          .classed("terminal", function(d) { console.log(d.terminal); return d.terminal; })
+          .classed("terminal", function(d) { return d.terminal; })
       ;
       mensurations = markings
         .append("g")

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -81,11 +81,13 @@ function NotesBook() {
       ;
       barlinesScale  = x.copy().range([margin.left, fw - margin.right]);
 
-      // This axis is used for rendering the bar lines (always a fixed number of lines).
+      // This axis is used for rendering the bar lines and labels.
       barlinesAxis = d3.axisBottom()
           .scale(barlinesScale.clamp(true))
           .tickValues(data.barlines.map(function(b) { return b.time[0]; }))
-          .tickFormat(function (d, i){ return data.barlines[i].label; })
+          .tickFormat(function (d, i){
+              return data.barlines[i].label;
+          })
           .tickSize(h)
       ;
 
@@ -109,7 +111,7 @@ function NotesBook() {
         .append("g")
           .attr("class", "barlines haxis")
           .attr("transform", "translate(0," + margin.top + ")")
-          .call(barlinesAxis)
+          .call(renderBarlines)
       ;
       barlines.selectAll(".tick")
           .classed("terminal", function(d) { console.log(d.terminal); return d.terminal; })
@@ -190,6 +192,24 @@ function NotesBook() {
   /*
   ** Helper Functions
   */
+  function renderBarlines(selection){
+
+      // Compute the set of bar labels to show.
+      var t0 = barlinesScale.domain()[0],
+          t1 = barlinesScale.domain()[1],
+          visibleBarsExtent = d3.extent(
+              data.barlines.filter(function(b){
+                  var t = b.time[0];
+                  return b.label && t > t0 && t < t1;
+              })
+              .map(function(b){ return +b.label; })
+          );
+          
+      console.log(visibleBarsExtent);
+
+      selection.call(barlinesAxis);
+  }
+
 
   /*
   ** API (Getter/Setter) Functions
@@ -238,8 +258,8 @@ function NotesBook() {
       vb[2] = Math.abs(_[1] - _[0]);
       barlinesScale.domain([vb[0], vb[0] + vb[2]].map(x.invert));
 
-      barlines.call(barlinesAxis.scale(barlinesScale.clamp(true)));
-      measures.call(measuresAxis.scale(barlinesScale.clamp(true)));
+      barlinesAxis.scale(barlinesScale.clamp(true))
+      barlines.call(renderBarlines);
       mensurations.call(mensurationsAxis.scale(barlinesScale.clamp(false)));
 
       lens.attr("viewBox", vb.join(' ') );

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -26,7 +26,7 @@ function NotesBook() {
           , "C|" : ""
           , "C|r": ""
         }
-    , barlines, barlinesScale, barlinesAxis
+    , barlines, barlinesScale, barlinesAxis, barLabels, barLabelCount = 15
     , mensurations, mensurationsLocs, mensurationsAxis
     , dispatch
   ;
@@ -86,9 +86,13 @@ function NotesBook() {
           .scale(barlinesScale.clamp(true))
           .tickValues(data.barlines.map(function(b) { return b.time[0]; }))
           .tickFormat(function (d, i){
-              return data.barlines[i].label;
+
+              // barLabels is a dictionary for the "ticks" to include.
+              // It is computed inside renderBarlines before rendering the axis.
+              var label = data.barlines[i].label;
+              return barLabels[label] ? label : "";
           })
-          .tickSize(h)
+          .tickSize(h) // Make the line span the vertical space.
       ;
 
       // Locations for changes in mensuration.
@@ -192,23 +196,32 @@ function NotesBook() {
   /*
   ** Helper Functions
   */
+
+  // This function renders the bar lines and labels.
   function renderBarlines(selection){
 
       // Compute the set of bar labels to show.
       var t0 = barlinesScale.domain()[0],
           t1 = barlinesScale.domain()[1],
-          visibleBarsExtent = d3.extent(
+          labelsExtent = d3.extent(
               data.barlines.filter(function(b){
                   var t = b.time[0];
-                  return b.label && t > t0 && t < t1;
+                  return b.label && t >= t0 && t <= t1;
               })
               .map(function(b){ return +b.label; })
-          );
-          
-      console.log(visibleBarsExtent);
+          ),
+          ticks = d3.ticks(labelsExtent[0], labelsExtent[1], barLabelCount);
 
+      // Store the collection of label "ticks" in barLabels,
+      // which is used in the tickFormat function of barlinesAxis.
+      barLabels = {};
+      ticks.forEach(function (tick){
+          barLabels[tick] = true;
+      });
+
+      // Render the axis, which includes both lines and labels.
       selection.call(barlinesAxis);
-  }
+  } // renderBarlines()
 
 
   /*

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -27,7 +27,6 @@ function NotesBook() {
           , "C|r": ""
         }
     , barlines, barlinesScale, barlinesAxis
-    , measures, measuresAxis
     , mensurations, mensurationsLocs, mensurationsAxis
     , dispatch
   ;
@@ -81,15 +80,16 @@ function NotesBook() {
           .call(reflines.x(x).y(y.copy().range([fh - margin.bottom, margin.top])))
       ;
       barlinesScale  = x.copy().range([margin.left, fw - margin.right]);
-      barlinesAxis = d3.axisTop()
+
+      // This axis is used for rendering the bar lines (always a fixed number of lines).
+      barlinesAxis = d3.axisBottom()
           .scale(barlinesScale.clamp(true))
           .tickValues(data.barlines.map(function(b) { return b.time[0]; }))
-          .tickSize(-h)
+          .tickFormat(function (d, i){ return data.barlines[i].label; })
+          .tickSize(h)
       ;
-      measuresAxis = d3.axisBottom()
-          .scale(barlinesScale.clamp(true))
-          .tickSize(0)
-      ;
+
+      // Locations for changes in mensuration.
       mensurationsLocs = data.barlines
           .filter(function(d) { return d.mensuration; })
       ;
@@ -113,12 +113,6 @@ function NotesBook() {
       ;
       barlines.selectAll(".tick")
           .classed("terminal", function(d) { console.log(d.terminal); return d.terminal; })
-      ;
-      measures = markings
-        .append("g")
-          .attr("class", "measures haxis")
-          .attr("transform", "translate(0," + (fh - margin.bottom) + ")")
-          .call(measuresAxis)
       ;
       mensurations = markings
         .append("g")


### PR DESCRIPTION
This PR implements a solution for rendering the bar labels along with the bar lines, but using a fewer number of labels similar to tick marks. Uses [d3.ticks](https://github.com/d3/d3-array#ticks) to compute the set of labels to include. Robust to mensuration changes (same interval used throughout time, unlike the [previous solution](https://github.com/sul-cidr/josquin-ribbon/pull/63)).

![image](https://cloud.githubusercontent.com/assets/68416/22974367/fab49118-f3a7-11e6-886a-0ed1601362df.png)
Zoomed out, showing behavior over mensuration changes.

![image](https://cloud.githubusercontent.com/assets/68416/22974439/4ddcb622-f3a8-11e6-8c92-6374216f0ab0.png)
Zoomed in, showing the numbers are bar numbers, not beat numbers.


Closes #60