### PR TITLE
Shorten svg for download

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -38,6 +38,7 @@ svg {
     stroke: currentColor;
     fill-opacity: 0.5;
     stroke-width: 1;
+    vector-effect: non-scaling-stroke;
 }
 .subdued {
     opacity: 0.1;

--- a/js/dev/baton.js
+++ b/js/dev/baton.js
@@ -26,6 +26,7 @@ var signal = d3.dispatch(
 var baseURL = 'http://josquin.stanford.edu/cgi-bin/jrp?'
   , catURL = baseURL + 'a=list'
   , jsonURL = baseURL + 'a=proll-json&f='
+  , work // the currently displayed song
 ;
 
 /*
@@ -64,8 +65,9 @@ d3.select("#load_song").on("click", function() {
 window.onpopstate = function(event) {
     var defaultWork = "Jos2721"
       , hash = getQueryVariables()
-      , work = hash.id || defaultWork
     ;
+    work = hash.id || defaultWork;
+
     d3.select("input#josquin_catalog").node().value = work;
     d3.select("#load_song").node().click();
 } // window.onload()

--- a/js/dev/legend.js
+++ b/js/dev/legend.js
@@ -5,7 +5,6 @@ function ColorLegend(){
     var div
       , data
       , hilite
-      , noteHeight = 10
       , dispatch
     ;
 
@@ -13,6 +12,12 @@ function ColorLegend(){
     ** Main function object
     */
     function my() {
+        var width = 22
+          , noteWidth = width - 2
+          , height = noteWidth / 2
+          , noteHeight = height - 2
+          , radius = noteHeight / 2
+        ;
         var legend = div.selectAll("ul").data([1]);
         legend = legend.enter().append("ul")
             .attr("class", "list-unstyled")
@@ -28,17 +33,17 @@ function ColorLegend(){
                 self
                   .append("svg")
                     .attr("x", 0)
-                    .attr("y", noteHeight)
-                    .attr("width", 22)
-                    .attr("height", noteHeight)
+                    .attr("y", 0)
+                    .attr("width", width)
+                    .attr("height", height)
                     .attr("class", "voice" + i)
                   .append("rect")
                     .attr("x", 1)
-                    .attr("y", 0)
-                    .attr("rx", noteHeight / 2)
-                    .attr("ry", noteHeight / 2)
+                    .attr("y", 1)
+                    .attr("rx", radius)
+                    .attr("ry", radius)
                     .attr("height", noteHeight)
-                    .attr("width", noteHeight * 2)
+                    .attr("width", noteWidth)
                     .attr("class", "note")
                 ;
                 self
@@ -67,14 +72,8 @@ function ColorLegend(){
         if(arguments.length === 0) return height;
         height = value;
         return my;
-    };
-
-    my.noteHeight = function (value){
-        if(arguments.length === 0) return noteHeight;
-        noteHeight = value;
-        return my;
-    };
-
+      }
+    ;
     my.connect = function(value){
         if(!arguments.length) return dispatch;
         dispatch = value;

--- a/js/dev/legend.js
+++ b/js/dev/legend.js
@@ -32,9 +32,13 @@ function ColorLegend(){
                     .attr("width", 22)
                     .attr("height", noteHeight)
                     .attr("class", "voice" + i)
-                  .append("use")
+                  .append("rect")
                     .attr("x", 1)
-                    .attr("xlink:href", "#note-2")
+                    .attr("y", 0)
+                    .attr("rx", noteHeight / 2)
+                    .attr("ry", noteHeight / 2)
+                    .attr("height", noteHeight)
+                    .attr("width", noteHeight * 2)
                     .attr("class", "note")
                 ;
                 self

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -11,7 +11,7 @@ function NotesBook() {
     , margin = { top: "10%", right: "5%", bottom: "5%", left: "5%" }
     , percents = { left: 5, top: 15, right: 5, bottom: 5}
     , x = d3.scaleLinear()
-    , y = d3.scaleBand()
+    , y = d3.scaleBand().round(true)
     , score  = Score()
     , ribbon = Ribbon()
     , markings = Markings()

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -58,6 +58,8 @@ function NotesBook() {
           .attr("height", (100 - percents.top - percents.bottom) + "%")
       ;
       voices
+          .attr("width", width)
+          .attr("height", height)
           .attr("viewBox", [0, 0, width, height].join(' '))
       ;
       var voice = voices.selectAll(".voice")

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -58,8 +58,6 @@ function NotesBook() {
           .attr("height", (100 - percents.top - percents.bottom) + "%")
       ;
       voices
-          .attr("width", width)
-          .attr("height", height)
           .attr("viewBox", [0, 0, width, height].join(' '))
       ;
       var voice = voices.selectAll(".voice")
@@ -107,8 +105,6 @@ function NotesBook() {
       ;
       rulers = svg.append("svg")
         .attr("class", "markings")
-        .style("width", "100%")
-        .style("height", "100%")
       ;
       reticle = svg
         .append("svg")

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -53,6 +53,7 @@ function NotesBook() {
       ;
       reticle
           .attr("viewBox", [0, 0, width, height].join(' '))
+        // Make room for the markings around
           .attr("width", (100 - percents.left - percents.right) + "%")
           .attr("height", (100 - percents.top - percents.bottom) + "%")
       ;
@@ -79,7 +80,7 @@ function NotesBook() {
           .attr("viewBox", viewbox.join(' '))
           .each(function() {
               d3.select(this)
-                  .call(score.x(x).y(y).defs(defs))
+                  .call(score.x(x).y(y))
                   .call(ribbon.x(x).y(y))
               // Initially, don't show the ribbons
                 .selectAll(".ribbon")
@@ -116,12 +117,6 @@ function NotesBook() {
         .attr("x", percents.left + "%")
         .attr("y", percents.top + "%" )
       ;
-      defs = reticle
-        .append("defs")
-      ;
-      // Create a space for the note rectangles of various time durations
-      defs.append("g").attr("id", "notestamps");
-
       voices = reticle
         .append("svg")
           .attr("class", "voices")

--- a/js/dev/ribbon.js
+++ b/js/dev/ribbon.js
@@ -38,9 +38,8 @@ function Ribbon() {
                   .data([modes[m](datum.notedata)]) // call the mode function
               ;
               path.exit().remove();
-              path
-                .enter().append("path")
-                  .attr("vector-effect", "non-scaling-stroke")
+              path.enter()
+                .append("path")
                 .merge(path)
                   .attr("d", area)
               ;

--- a/js/dev/ribbon.js
+++ b/js/dev/ribbon.js
@@ -2,7 +2,6 @@ function Ribbon() {
     /* Private Variables */
     var datum
       , x, y
-      , stamps
       , interval = 12 // Interval size for the sliding window, in units of beats
       , step = 1 // How much to slide the window for each iteration.
       , bandwidth = 1 // Scaling factor * std.dev. before +ing/-ing from mean.
@@ -12,7 +11,7 @@ function Ribbon() {
                 .y0(function (d){ return y(d.y0); })
                 .y1(function (d){ return y(d.y1); })
                 .curve(d3.curveBasis)
-                (data)
+              (data)
             ;
           }
       , modes = {}
@@ -262,13 +261,6 @@ function Ribbon() {
           ]);
         return my;
       } // my.y()
-    ;
-    my.defs = function(_) {
-        if(!arguments.length)
-            return stamps;
-        stamps = _;
-        return my;
-      } // my.stamps()
     ;
     my.bbox = function() {
         return [];

--- a/js/dev/score.js
+++ b/js/dev/score.js
@@ -34,7 +34,7 @@ function Score() {
 
       var noteHeight = y.bandwidth();
 
-      note = note.enter()
+      var noteEnter = note.enter()
         .append("rect")
           .attr("class", "note")
           .attr("x", function(d) { return x(d.starttime[0]); })
@@ -47,6 +47,13 @@ function Score() {
               return ~pitches.indexOf(d.pitch.b7);
             })
       ;
+
+      noteEnter.append("title")
+        .merge(note.select("title"))
+        .text(function (d){
+            return d.pitch.name + " : " + d.duration + " beats" + " (" + data.voice + ")";
+        });
+
   } // my()
 
   /*

--- a/js/dev/score.js
+++ b/js/dev/score.js
@@ -8,14 +8,12 @@ function Score() {
     , y // scale for global domain
     , pitches
     , times
-    , stamps
   ;
   /*
   ** Main Function Object
   */
   function my(sel) {
       data = sel.datum();
-      stampify();
       boxify(data.notedata);
 
       var svg = sel.select(".notes");
@@ -26,43 +24,27 @@ function Score() {
       ;
       svg.selectAll(".note").remove(); // Clear out all existing notes
 
-      var notes = svg.selectAll(".note")
+      var note = svg.selectAll(".note")
           .data(
                 function(d) { return d.notedata; }
               , function(d) { return d.starttime[0]; }
             )
       ;
+      note.exit().remove();
 
-      notes.exit().remove();
+      var noteHeight = y.bandwidth();
 
-      notes.enter()
-        .append("use")
+      note = note.enter()
+        .append("rect")
+          .attr("class", "note")
           .attr("x", function(d) { return x(d.starttime[0]); })
           .attr("y", function(d) { return y(d.pitch.b7); })
-          .attr("xlink:href", function(d) {
-              return "#note-" + d.duration[0];
-            })
-          .attr("class", "note")
+          .attr("rx", noteHeight / 2)
+          .attr("ry", noteHeight / 2)
+          .attr("height", noteHeight)
+          .attr("width", function(d) { return x(+d.duration[0]); })
           .classed("extreme-plain", function(d) {
               return ~pitches.indexOf(d.pitch.b7);
-            })
-          .each(function(d) {
-              /*
-              ** a11y: screen readers will find all the information about the
-              **      note here.
-              ** side-effect: browser tooltips in ff and chrome.
-              */
-              var self = d3.select(this)
-                , title = d.pitch.name + " : "
-                    + d.duration + " beats"
-                    + " (" + data.voice + ")"
-              ;
-              self.append("title")
-                  .text(title)
-              ;
-              self.append("desc")
-                  .text(title)
-              ;
             })
       ;
   } // my()
@@ -70,28 +52,6 @@ function Score() {
   /*
   ** Helper Functions
   */
-  function stampify() {
-      // Create notes of various widths, as found in the notedata
-      var noteHeight = y.bandwidth()
-        , durations = d3.nest()
-              .key(function(n) { return n.duration[0]; })
-              .map(data.notedata)
-            .keys()
-              .sort(d3.ascending)
-      ;
-      stamps.selectAll("rect")
-          .data(durations, function(d) { return d; })
-        .enter().append("rect")
-          .attr("id", function(d) { return "note-" + d; })
-          .attr("rx", noteHeight / 2)
-          .attr("ry", noteHeight / 2)
-          .attr("height", noteHeight)
-          .attr("width", function(d) { return x(+d); })
-          .attr("vector-effect", "non-scaling-stroke")
-      ;
-      stamps.exit().remove();
-  } // stampify()
-
   function boxify(notes) {
       pitches = d3.extent(notes.map(function(d) { return d.pitch.b7; }));
       times = [notes[0], notes[notes.length - 1]];
@@ -111,12 +71,6 @@ function Score() {
       y = _;
       return my;
     } // my.y()
-  ;
-  my.defs = function(_) {
-      if(!arguments.length) return stamps;
-      stamps = _.select("#notestamps");
-      return my;
-    } // my.stamps()
   ;
   my.bbox = function() {
       return [


### PR DESCRIPTION
@curran, this is ready for testing -- when I looked at the svg strings, I saw some things to clean up:

- while `<use>` is great for inline SVGs, as a serialized string each xlink:href call has a corollary XML namespace statement with it: every. single. one.  that was thousands of needless strings!
- the non-scaling-stroke style was declared as an attribute on every single note.  again, thousands of needless strings!
- the y-coordinates for the notes were ridiculously precise (7-8 digits after the decimal point, we can do better!)

So, the fixes then:
- go back to the plain old `<rect>` calls to construct notes.  This had to be done for legend as well -- there's some repeating code, but blah.
  - the `<title>` attribute from `<use>` was also removed.
     - tooltips are lost for the moment.
- the non-scaling-stroke style was moved into the stylesheets
- the scaleBand is now rounded

This now works with pieces like Jos1910.  Please feel free to test, as we may still need to consider further optimizations.