### PR TITLE
Add fractions column

### DIFF
--- a/_data/mensurations.csv
+++ b/_data/mensurations.csv
@@ -1,32 +1,31 @@
-sign,num_beats,num_quarter_notes,symbols,MUSIC,COMMENTS
-C|,2,8,,,
-O,3,12,,,
-C,2,8,,,
-3,3,12,,,
-C,2,8,,,
-O|,3,12,,,
-C|3,3,12,C|;3;,,
-O/3,3,12,;O;3,,
-O,3,12,,,
-C,2,1,,,
-C.,2,12,,,"This is effectively ""compound time,"" with the dotted whole note getting the beat. (6/2, like our modern 6/8)."
-O.,3,18,,,as above
-3/2,3,12,;3;2,,"depends on the context, but this is probably right. Worth double-checking"
-O,3,12,,,
-C|2,2,16,C|;2;,,Time signature is 2 double whole notes (!) per measure.
-2,2,16,,,"depends on the context, but this is probably right. Worth double-checking"
-O3/2,3,12,O;3;2,,
-O|3/2,3,12,O|;3;2,,
-O|3,3,12,O|;3;,,
-C.3/2,2,12,C.;3;2,,"This is effectively ""compound time,"" with the dotted whole note getting the beat. (6/2, like our modern 6/8)."
-C,2,8,,,
-C|/3,3,12,;C|;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0406d&a=humdrum,
-C.,2,12,,,Compound time
-C|/2,2,8,;C|;2,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0902d&a=humdrum,
-C2/3,2,8,C;2;3,,
-2/1,2,8,;2;1,,
-C|r,2,16,,http://josquin.stanford.edu/cgi-bin/jrp?id=Bus1001c&a=humdrum,"Ah, this is reverse C, which means 4:3 relative to C."
-C|,2,8,,,
-4/3,2,16,;4;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Tin2001&a=humdrum,
-C.3/8,2,12,C.;3;8,,
-2/3,2,8,;2;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Tin2001&a=humdrum,
+sign,num_beats,num_quarter_notes,relative_measure_duration,symbols,MUSIC,COMMENTS
+C|,2,8,1/2,,,
+O,3,12,1,,,
+C,2,8,,,,
+3,3,12,1/2,,,
+C,2,8,,,,
+O|,3,12,3/4,,,
+C|3,3,12,1,C|;3;,,
+O/3,3,12,1/2,;O;3,,
+O,3,12,,,,
+C,2,1,,,,
+C.,2,12,,,,"This is effectively ""compound time,"" with the dotted whole note getting the beat. (6/2, like our modern 6/8)."
+O.,3,18,,,,as above
+3/2,3,12,,;3;2,,"depends on the context, but this is probably right. Worth double-checking"
+O,3,12,,,,
+C|2,2,16,,C|;2;,,Time signature is 2 double whole notes (!) per measure.
+2,2,16,,,,"depends on the context, but this is probably right. Worth double-checking"
+O3/2,3,12,,O;3;2,,
+O|3/2,3,12,,O|;3;2,,
+O|3,3,12,,O|;3;,,
+C.3/2,2,12,,C.;3;2,,"This is effectively ""compound time,"" with the dotted whole note getting the beat. (6/2, like our modern 6/8)."
+C,2,8,,,,
+C|/3,3,12,,;C|;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0406d&a=humdrum,
+C.,2,12,1,,,Compound time
+C|/2,2,8,1/4,;C|;2,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0902d&a=humdrum,
+C2/3,2,8,,C;2;3,,
+2/1,2,8,,;2;1,,
+C|r,2,16,,,http://josquin.stanford.edu/cgi-bin/jrp?id=Bus1001c&a=humdrum,"Ah, this is reverse C, which means 4:3 relative to C."
+4/3,2,16,,;4;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Tin2001&a=humdrum,
+C.3/8,2,12,,C.;3;8,,
+2/3,2,8,,;2;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Tin2001&a=humdrum,

--- a/_data/mensurations.csv
+++ b/_data/mensurations.csv
@@ -4,12 +4,9 @@ C|,2,8,1/2,,,
 O,3,12,1,,,
 C,2,8,2/3,,,
 3,3,12,1/2,,,
-C,2,8,2/3,,,duplicate
 O|,3,12,3/4,,,
 C|3,3,12,1,C|;3;,,
 O/3,3,12,1/2,;O;3,,
-O,3,12,1,,,duplicate
-C,2,1,2/3,,,"This looks like an error. Shouldn't there be 8 quarter notes, as in row 6?"
 C.,2,12,1,,,"This is effectively ""compound time,"" with the dotted whole note getting the beat. (6/2, like our modern 6/8)."
 O.,3,18,3/2,,,as above
 3/2,3,12,,;3;2,,In which piece(s) does this sign appear?
@@ -20,7 +17,6 @@ O|3/2,3,12,1/2,O|;3;2,,
 O|3,3,12,1/2,O|;3;,,
 C.3/2,2,12,,C.;3;2,,In which piece(s) does this sign appear?
 C|/3,3,12,1/2,;C|;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0406d&a=humdrum,
-C.,2,12,1,,,Compound time
 C|/2,2,16,1/2,;C|;2,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0902d&a=humdrum,
 C2/3,2,8,,C;2;3,,In which piece(s) does this sign appear?
 2/1,2,16,1/2,;2;1,,In which piece(s) does this sign appear?

--- a/_data/mensurations.csv
+++ b/_data/mensurations.csv
@@ -1,31 +1,30 @@
 sign,num_beats,num_quarter_notes,relative_measure_duration,symbols,MUSIC,COMMENTS
+O2,3,8,1/2,,,I'm not sure why this one wasn't on the list: I've just added it.
 C|,2,8,1/2,,,
 O,3,12,1,,,
-C,2,8,,,,
+C,2,8,2/3,,,
 3,3,12,1/2,,,
-C,2,8,,,,
+C,2,8,2/3,,,duplicate
 O|,3,12,3/4,,,
 C|3,3,12,1,C|;3;,,
 O/3,3,12,1/2,;O;3,,
-O,3,12,,,,
-C,2,1,,,,
-C.,2,12,,,,"This is effectively ""compound time,"" with the dotted whole note getting the beat. (6/2, like our modern 6/8)."
-O.,3,18,,,,as above
-3/2,3,12,,;3;2,,"depends on the context, but this is probably right. Worth double-checking"
-O,3,12,,,,
-C|2,2,16,,C|;2;,,Time signature is 2 double whole notes (!) per measure.
-2,2,16,,,,"depends on the context, but this is probably right. Worth double-checking"
-O3/2,3,12,,O;3;2,,
-O|3/2,3,12,,O|;3;2,,
-O|3,3,12,,O|;3;,,
-C.3/2,2,12,,C.;3;2,,"This is effectively ""compound time,"" with the dotted whole note getting the beat. (6/2, like our modern 6/8)."
-C,2,8,,,,
-C|/3,3,12,,;C|;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0406d&a=humdrum,
+O,3,12,1,,,duplicate
+C,2,1,2/3,,,"This looks like an error. Shouldn't there be 8 quarter notes, as in row 6?"
+C.,2,12,1,,,"This is effectively ""compound time,"" with the dotted whole note getting the beat. (6/2, like our modern 6/8)."
+O.,3,18,3/2,,,as above
+3/2,3,12,,;3;2,,In which piece(s) does this sign appear?
+C|2,2,16,1/2,C|;2;,,Time signature is 2 double whole notes (!) per measure.
+2,2,16,1/2,,,"depends on the context, but this is probably right. Worth double-checking"
+O3/2,3,12,1,O;3;2,,In which piece(s) does this sign appear?
+O|3/2,3,12,1/2,O|;3;2,,
+O|3,3,12,1/2,O|;3;,,
+C.3/2,2,12,,C.;3;2,,In which piece(s) does this sign appear?
+C|/3,3,12,1/2,;C|;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0406d&a=humdrum,
 C.,2,12,1,,,Compound time
-C|/2,2,8,1/4,;C|;2,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0902d&a=humdrum,
-C2/3,2,8,,C;2;3,,
-2/1,2,8,,;2;1,,
-C|r,2,16,,,http://josquin.stanford.edu/cgi-bin/jrp?id=Bus1001c&a=humdrum,"Ah, this is reverse C, which means 4:3 relative to C."
-4/3,2,16,,;4;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Tin2001&a=humdrum,
-C.3/8,2,12,,C.;3;8,,
-2/3,2,8,,;2;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Tin2001&a=humdrum,
+C|/2,2,16,1/2,;C|;2,http://josquin.stanford.edu/cgi-bin/jrp?id=Jos0902d&a=humdrum,
+C2/3,2,8,,C;2;3,,In which piece(s) does this sign appear?
+2/1,2,16,1/2,;2;1,,In which piece(s) does this sign appear?
+C|r,2,16,1/2,,http://josquin.stanford.edu/cgi-bin/jrp?id=Bus1001c&a=humdrum,"Ah, this is reverse C, which means 4:3 relative to C."
+4/3,2,16,1/2,;4;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Tin2001&a=humdrum,
+C.3/8,2,12,1/2,C.;3;8,,
+2/3,2,8,1/2,;2;3,http://josquin.stanford.edu/cgi-bin/jrp?id=Tin2001&a=humdrum,


### PR DESCRIPTION
This PR incorporates the fractions table from issue #144 into `mensurations.csv`.

There are two sources of difficulty here:

 * The names used for referring to mensurations is not common between the two tables, so we had to do a bit of guesswork.
 * Not all entries have fractions associated with them.