### PR TITLE
Measure Scaling Fixes, Part II

### DIFF
--- a/js/dev/measureScaling.js
+++ b/js/dev/measureScaling.js
@@ -33,28 +33,51 @@ var measureScaling = (function (){
     // and the value is the number of beats in that measure.
     function annotateMeasures(proll, mensurationsLUT){
 
-        // Keeps track of the last seen mensuration value.
+        // Keeps track of the last seen (current) mensuration.
         var mensuration;
 
+        // This variable tracks the number of quarter notes per measure
+        // in the current mensuration, as determined from adjacent barline times.
+        var numQuarterNotes;
+
         // Create indices from the lookup table.
-        var mensurationsToBeats = {};
         var mensurationsToRelativeDuration = {};
         mensurationsLUT.forEach(function (d){
-            mensurationsToBeats[d.sign] = d.num_quarter_notes;
             mensurationsToRelativeDuration[d.sign] = parseRelativeDuration(d.relative_measure_duration);
         });
 
+
         return proll.barlines.map(function (d, i){
 
-            // Fill in "undefined" mensuration values with last seen value.
-            mensuration = (d.mensuration || mensuration);
+            // If we are facing a change in mensuration (or the first bar),
+            if(d.mensuration){
+                // let's use the data to determine how many quarter notes
+                // are in each measure for this particular mensuration.
+                // We do this because we've noticed that the same mensuration in 
+                // different pieces doesn't necessarily have the same number of quarter notes.
+
+                // First, we get the time (which is in units of quarter notes)
+                // from the current bar and the next bar.
+                var bar0Time = +proll.barlines[i].time[0];
+                var bar1Time = +proll.barlines[i + 1].time[0];
+
+                // Then we take the difference between these times, and use that
+                // as the number of quarter notes per measure,
+                // which will not change until the mensuration changes again.
+                numQuarterNotes = bar1Time - bar0Time;
+
+                // Set the current mensuration when the mensuration changes,
+                // and this value will be used for future bars with this mensuration
+                // (as d.mensuration is not defined unless mensuration changes).
+                mensuration = d.mensuration;
+            }
 
             // Return an "annotated measure" object, that contains
             // useful information about each measure based on information
             // from the mensurationsLUT.
             var annotatedMeasure = {
                 mensuration: mensuration,
-                numBeats: mensurationsToBeats[mensuration],
+                numBeats: numQuarterNotes,
                 relativeDuration: mensurationsToRelativeDuration[mensuration]
             };
             //console.log(JSON.stringify(annotatedMeasure));

--- a/js/dev/measureScaling.js
+++ b/js/dev/measureScaling.js
@@ -40,6 +40,10 @@ var measureScaling = (function (){
         // in the current mensuration, as determined from adjacent barline times.
         var numQuarterNotes;
 
+        // This variable tracks the relative duration of one measure
+        // in the current mensuration, as determined from the lookup table.
+        var relativeDuration;
+
         // Create indices from the lookup table.
         var mensurationsToRelativeDuration = {};
         mensurationsLUT.forEach(function (d){
@@ -70,16 +74,31 @@ var measureScaling = (function (){
                 // and this value will be used for future bars with this mensuration
                 // (as d.mensuration is not defined unless mensuration changes).
                 mensuration = d.mensuration;
+
+                // Look up the relative duration for the current mensuration
+                // from the lookup table loade in from the CSV file.
+                relativeDuration = mensurationsToRelativeDuration[mensuration]
+
+                // If relative duration is missing from the table,
+                if(!relativeDuration){
+                    // Flag it to developers as missing.
+                    console.error("Error: missing value for column relative_measure_duration in mensurations table for sign '" + mensuration + "'. Falling back to a value of 1.");
+
+                    // Fall back to a value of 1, which may be incorrect,
+                    // but it's better than breaking completely and not showing
+                    // any notes in sections with this mensuration.
+                    relativeDuration = 1;
+                }
             }
 
             // Return an "annotated measure" object, that contains
-            // useful information about each measure based on information
-            // from the mensurationsLUT.
+            // information about each measure used for scaling later.
             var annotatedMeasure = {
                 mensuration: mensuration,
                 numBeats: numQuarterNotes,
-                relativeDuration: mensurationsToRelativeDuration[mensuration]
+                relativeDuration: relativeDuration
             };
+
             //console.log(JSON.stringify(annotatedMeasure));
             return annotatedMeasure;
         });


### PR DESCRIPTION
This PR implements the direction encouraged by @seemantk on our last call, which is to handle inconsistencies in the number of quarter notes for the same mensuration across different pieces by deriving the number of quarter notes per measure from the barlines data, not the spreadsheet.