### PR TITLE
State Management Fixes

### DIFF
--- a/js/dev/markings.js
+++ b/js/dev/markings.js
@@ -116,10 +116,12 @@ function Markings() {
       y.range([height - margin.bottom, margin.top]);
       voices.range(y.range());
 
+      // TODO move this block into the render function (my())
       reflines.call(renderReflines);
       barlines.call(renderBarlines);
       mensurations.call(renderMensurations);
       sections.call(renderSections);
+
   } // resize()
 
   /*
@@ -272,7 +274,9 @@ function Markings() {
   my.data = function (_){
       if(!arguments.length) return data;
 
+      // TODO move this into render function, use .exit()
       if(reflines) reflines.selectAll(".refline").remove();
+
       data = _;
       height = width = null;
       return my;
@@ -293,6 +297,8 @@ function Markings() {
   my.xDomain = function(_) {
       if(!arguments.length) return x.domain();
       x.domain(_);
+
+      // TODO move this (entire block) into render function
       barlinesAxis.scale(barlinesScale.clamp(true));
       barlines.call(renderBarlines);
       mensurationsAxis.scale(barlinesScale.clamp(true));
@@ -326,6 +332,8 @@ function Markings() {
       if(!arguments.length) return separate;
 
       separate = _;
+
+      // TODO move this into render function
       reflines.call(renderReflines);
 
       return my;

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -178,6 +178,8 @@ function NotesBook() {
     } // my.connect()
   ;
   my.hilite = function(_) {
+
+      // TODO move this into render function, introduce variable.
         if(!_[0])
             voices.selectAll(".subdued")
                 .classed("subdued", false)
@@ -185,11 +187,14 @@ function NotesBook() {
             voices.selectAll("svg")
                 .classed("subdued", function(d, i) { return i !== _[1]; })
             ;
+
       return my;
     } // my.hilite()
   ;
   my.extremes = function() {
       var xtrms = voices.selectAll(".extreme").empty();
+
+      // TODO move this into render function, introduce variable.
       voices.selectAll(".extreme-plain")
           .classed("extreme", xtrms)
       ;
@@ -199,10 +204,10 @@ function NotesBook() {
       var vb = reticle.attr("viewBox").split(' ');
       if(!arguments.length) return vb;
 
+      // TODO move this into render function.
       vb[0] = _[0];
       vb[2] = Math.abs(_[1] - _[0]);
       markings.xDomain([vb[0], vb[0] + vb[2]].map(x.invert));
-
       reticle.attr("viewBox", vb.join(' ') );
 
       return my;
@@ -213,6 +218,7 @@ function NotesBook() {
       var vb = voices.attr("viewBox").split(' ');
       vb[3] = _ ? fullheight : height;
 
+      // TODO move this into render function.
       voices
         .transition(d3.transition())
           .attr("viewBox", vb.join(' '))
@@ -224,6 +230,8 @@ function NotesBook() {
     } // my.separate()
   ;
   my.notes = function() { // toggles the notes on/off
+
+      // TODO move this into render function, introduce variable.
       var music = voices.selectAll(".notes")
         , vis = music.style("display")
       ;
@@ -231,6 +239,8 @@ function NotesBook() {
     } // my.notes()
   ;
   my.ribbons = function(arg) {
+
+      // TODO move this into render function, introduce variable.
       voices.selectAll(".ribbon")
           .style("display", function(d) {
               return d.toLowerCase() === arg ? "inline" : "none";


### PR DESCRIPTION
This PR is about addressing the following issues:

 * Take brush into account on measure scaling changes #147
 * Fix issue with split/combine WITH measure-based scaling #154

The idea behind this is that in certain places in the code, we have getter/setter functions that *also* perform DOM manipulation, which means that when the render function is invoked later, it doesn't have enough information to faithfully render correctly.

Confounding state management (getter/setter) and rendering (DOM manipulation) worked well here for a long time, but now that we have more "state variables", we need to take measures to ensure that the DOM manipulation code ("render function") in our components knows about and takes into account all the pieces of state (e.g. brush interval, split/combine, selected voice, measure scaling) required to render correctly.
