### PR TITLE
Update labels. Fixes #170

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 	The following include contains the mensuration symbols
 	for all current mensuration signs in the JRP database.
 	The symbols are IDed by their proll JSON data name, with the
-	following transform needed to convert from the JSON string 
+	following transform needed to convert from the JSON string
 	to the ID of the mensuration in the symbol table, where mentag
 	is the name in the JSON file, and menid is the corresponding
 	symbol id for the desired symbol in the following list.
@@ -104,8 +104,8 @@
                     <label for="show-ribbon">
                       <input id="show-ribbon" type="checkbox" value="all">  Show Ribbon: <select id="select-ribbon">
                         <optgroup label="Select a Ribbon">
-                          <option value="standard_deviation">Standard Deviation</option>
-                          <option value="attack_density">Attack Density</option>
+                          <option value="standard_deviation">Melodic Contour</option>
+                          <option value="attack_density">Rhythmic Activity</option>
                         </optgroup>
                       </select>
                     </label>


### PR DESCRIPTION
Fixes #170 

This PR only updates the labels in the current working version, not in the various demo* or old* versions of the project. 

I think it's sufficient to update the label, without changing the underlying code that still refers to ATTACK_DENSITY or STANDARD_DEVIATION.