### PR TITLE
Duration Indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,9 @@
               <div class="list-group">
                 <button id="export-svg-button">Export SVG</button>
               </div><!--.list-group-->
+              <div class="list-group">
+                <span id="zoomed-duration-indicator"></span>
+              </div><!--.list-group-->
             </div><!--.panel-footer-->
           </div><!--.panel-->
         </div><!--.col-xs-12.col-lg-2-->

--- a/js/dev/baton.js
+++ b/js/dev/baton.js
@@ -120,6 +120,8 @@ function setupDispatcher() {
 } // setupDispatcher()
 
 function createSignals() {
+
+    // Pass each event into notesBook via accessors.
     signal
         .on("show-notes",      notesBook.notes)
         .on("show-extremes",   notesBook.extremes)
@@ -128,6 +130,13 @@ function createSignals() {
         .on("separate-voices", notesBook.separate)
         .on("zoom",            notesBook.zoom)
     ;
+
+    // Update the duration indicator on zoom.
+    signal.on("zoom.durationIndicator", function (extent){
+        var duration = extent[1] - extent[0];
+        var message = duration + " seconds selected";
+        d3.select("#zoomed-duration-indicator").text(message);
+    });
 } // createSignals()
 
 // Connect the UI control elements

--- a/js/dev/baton.js
+++ b/js/dev/baton.js
@@ -133,7 +133,7 @@ function createSignals() {
 
     // Update the duration indicator on zoom.
     signal.on("zoom.durationIndicator", function (extent){
-        var duration = extent[1] - extent[0];
+        var duration = (extent[1] - extent[0]) / 10;
         var message = duration + " seconds selected";
         d3.select("#zoomed-duration-indicator").text(message);
     });


### PR DESCRIPTION
The idea with this PR is that there will be some text within the UI that tells the user the duration of the brushed region in seconds. This is so that if different works are opened, the zoomed region can be manually adjusted to be the same duration, so they can be visually compared against one another.

Closes #179