### PR TITLE
Allow local installation of gems with bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ _site
 npm-debug.log
 Gemfile.lock
 .jekyll-metadata
+
+# environment normalization
+/.bundle
+/vendor

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 debugging: true
 
-exclude: [bower_components, node_modules, glyphs]
+exclude: [bower_components, node_modules, vendor, glyphs]
 
 markdown: kramdown
 kramdown:


### PR DESCRIPTION
This commit allows local installation of ruby gems with `bundle install --path vendor/bundle`.  `.gitignore` rules are added to prevent the `vendor/bundle` and `.bundle` directories being checked in, and the `vendor` path prefix is added to the `exclude` key in `_config.yaml` so that Jekyll doesn't try to build everything in there.