### PR TITLE
Adjust rhythmic ribbon window calculation

### DIFF
--- a/js/dev/ribbon.js
+++ b/js/dev/ribbon.js
@@ -149,8 +149,9 @@ function Ribbon() {
 
               // Consider the interval to start on the x value,
               // so it aligns with measures.
-              var windowStart = x
-                , windowEnd   = x + interval
+              // Shift window .5 intervals to the left for better fit
+              var windowStart = Math.max(0, x - (interval / 2))
+                , windowEnd = x + (interval / 2)
                 , noteStart = getTime.start(d)
               ;
 


### PR DESCRIPTION
This is just a small update to address a nagging issue with the "Rhythmic Activity" ribbon viz, specifically that the height of a voice's ribbon often is influenced by note attacks that happen much later, e.g., at the end of the measure. By shifting the "window" used for the ribbon height calculation half a time interval to the left, the viz can be made to fit the actual note activity better.