### PR TITLE
Enable flex-shrink for navigator ribbon

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -32,7 +32,7 @@ header {
 }
 
 #navigator {
-  flex: 1 0 auto;
+  flex: 1 1 auto;
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
This solves a problem with Firefox (observed on Mac OS) wherein the bottom navigator ribbon scrolls off the right edge of the page when the piece is sufficiently long (e.g., `http://127.0.0.1:7000/?id=Jos2720`). This doesn't happen with Chrome or Safari because apparently they don't check the `flex-shrink` value?