### PR TITLE
Update menu/viz interactions, maintain state

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,41 +77,35 @@
             </div><!--.panel-body-->
             <div class="panel-footer">
               <div class="list-group">
-                <!-- <div class="panel-body"> -->
-                  <div id="separate-ui">
-                    <label for="separate-voices">
-                      <input id="separate-voices" type="checkbox" autocomplete="off"> Separate Voices
-                    </label>
-                  </div>
-                <!-- </div> -->
+                <div id="ribbons-ui">
+                  <label for="show-ribbon">
+                    <input id="show-ribbon" type="checkbox" value="all" checked> Show Ribbon: 
+                  </label>
+                  <select id="select-ribbon">
+                    <optgroup label="Select a Ribbon">
+                      <option value="standard_deviation">Melodic Contour</option>
+                      <option value="attack_density" selected>Rhythmic Activity</option>
+                    </optgroup>
+                  </select>
+                </div><!--/#ribbons-ui-->
               </div><!--.list-group-->
               <div class="list-group">
-                <!-- <div class="panel-body"> -->
-                  <div id="notes-ui">
-                    <label for="show-notes">
-                      <input id="show-notes" type="checkbox" autocomplete="off" checked> Show Notes
-                    </label>
-                    <label for="show-extremes">
-                      <input id="show-extremes" type="checkbox" autocomplete="off"> Show Extreme Notes
-                    </label>
-                  </div><!--.btn-group#notes-ui-->
-                <!-- </div> -->
+                <div id="notes-ui">
+                  <label for="show-notes">
+                    <input id="show-notes" type="checkbox" autocomplete="off"> Show Notes
+                  </label>
+                  <label for="show-extremes" style="display: none">
+                    <input id="show-extremes" type="checkbox" autocomplete="off"> Hide Extreme Notes
+                  </label>
+                </div><!--.btn-group#notes-ui-->
               </div><!--.list-group-->
               <div class="list-group">
-                <!-- <div class="panel-body"> -->
-                  <div id="ribbons-ui">
-                    <label for="show-ribbon">
-                      <input id="show-ribbon" type="checkbox" value="all">  Show Ribbon:
-                    </label>
-                    <select id="select-ribbon">
-                      <optgroup label="Select a Ribbon">
-                        <option value="standard_deviation">Melodic Contour</option>
-                        <option value="attack_density">Rhythmic Activity</option>
-                      </optgroup>
-                    </select>
-                  </div><!--/#ribbons-ui-->
-                <!-- </div> -->
-              </div><!--.list-group-->
+                <div id="combine-ui" style="display: none">
+                  <label for="combine-voices">
+                    <input id="combine-voices" type="checkbox" autocomplete="off"> Combine Voices
+                  </label>
+                </div>
+              </div><!--.list-group#combine-ui-->
               <div class="list-group">
                 <button id="export-svg-button">Export SVG</button>
               </div><!--.list-group-->

--- a/js/dev/baton.js
+++ b/js/dev/baton.js
@@ -12,7 +12,7 @@ var margin = { top: 20, right: 20, bottom: 20, left: 20 }
           // List of signals we accept
           "hilite"
           , "zoom"
-          , "separate-voices"
+          , "combine-voices"
           , "selected"
           , "show-extremes"
           , "show-ribbon"
@@ -128,7 +128,7 @@ function createSignals() {
         .on("show-extremes",   notesBook.extremes)
         .on("hilite",          notesBook.hilite)
         .on("show-ribbon",     notesBook.ribbons)
-        .on("separate-voices", notesBook.separate)
+        .on("combine-voices",  notesBook.combine)
         .on("zoom",            notesBook.zoom)
     ;
 
@@ -144,7 +144,7 @@ function createSignals() {
 function connectSignalsToDOM() {
 
     // Combine/Separate Voices
-    d3.select("#separate-ui").selectAll("input")
+    d3.select("#combine-ui").selectAll("input")
         .on("change", function(d) {
             signal.call(this.id, this, this.checked)
         })
@@ -166,8 +166,6 @@ function connectSignalsToDOM() {
         , choice = d3.select(this).select("select")
         , callback = check.node().id // callback name == checkbox 'id'
       ;
-      // Hide the ribbon dropdown initially
-      choice.style("display", "none");
 
       check.on("change", function(d) {
           choice.style("display", this.checked ? null : "none");

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -102,7 +102,7 @@ function NotesBook() {
       my.notes(showNotes);
       my.combine(combineVoices);
       my.ribbons(selectedRibbon);
-      
+
       window.onresize = function(event) { markings.calibrate(); };
   } // my() - Main function object
 
@@ -175,12 +175,10 @@ function NotesBook() {
     } // my.hilite()
   ;
   my.extremes = function() {
-      var xtrms = voices.selectAll(".extreme").empty();
-
-      // TODO move this into render function, introduce variable.
-      voices.selectAll(".extreme-plain")
-          .classed("extreme", xtrms)
+      var music = voices.selectAll(".extreme-plain")
+        , vis = music.style("display")
       ;
+      music.style("display", vis === "inline" ? "none" : "inline");
     } // my.extremes()
   ;
   my.zoom = function(_) {

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -211,13 +211,35 @@ function NotesBook() {
       return my;
     } // my.separate()
   ;
-  my.notes = function() { // toggles the notes on/off
+  my.notes = function(_) { // toggles the notes on/off
 
       // TODO move this into render function, introduce variable.
       var music = voices.selectAll(".notes")
         , vis = music.style("display")
       ;
-      music.style("display", vis === "inline" ? "none" : "inline");
+      // Argument can be null if menu was previously disabled
+      if (_ === null) {
+        _ = vis !== "inline";
+      }
+
+      music.style("display", _ ? "inline" : "none");
+      // Only display "Hide Extreme Notes" when "Show Notes" is selected
+      d3.select(document.getElementById("show-notes").parentNode.nextElementSibling).style("display", _ ? "inline" : "none");
+
+      // Show staff lines/labels if melodic ribbon is selected
+      // or if no ribbons are shown (meaning notes must be shown)
+      if (!showRibbon || selectedRibbon != "standard_deviation") {
+        d3.selectAll(".refline")
+          .style("display", _ ? "inline" : "none");
+        ;
+      }
+
+      // If notes are turned off and no ribbon is enabled, show default ribbon
+      if (!_ && !showRibbon) {
+        my.ribbons("attack_density");
+      }
+
+      showNotes = _;
     } // my.notes()
   ;
   my.ribbons = function(arg) {

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -194,19 +194,20 @@ function NotesBook() {
       return my;
     } // my.zoom()
   ;
-  my.separate = function(_) {
+  my.combine = function(_) {
       // Art-direct the various voice SVGs
       var vb = voices.attr("viewBox").split(' ');
-      vb[3] = _ ? fullheight : height;
+      vb[3] = _ ? height : fullheight;
 
       // TODO move this into render function.
       voices
         .transition(d3.transition())
           .attr("viewBox", vb.join(' '))
         .selectAll(".voice")
-          .attr("y", function(d, i) { return _ ? i * height : 0; })
+          .attr("y", function(d, i) { return _ ? 0 : i * height; })
       ;
-      markings.separate(_);
+      markings.separate(!_);
+      combineVoices = _;
       return my;
     } // my.separate()
   ;

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -18,6 +18,10 @@ function NotesBook() {
     , lifeSize = 10 // default height and width of notes
     , scaleup = function(d) { return d * lifeSize; }
     , dispatch
+    , showNotes = false
+    , combineVoices = false
+    , showRibbon = true
+    , selectedRibbon = "attack_density"
   ;
 
   /*

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -22,6 +22,7 @@ function NotesBook() {
     , combineVoices = false
     , showRibbon = true
     , selectedRibbon = "attack_density"
+    , hideExtremes = false
   ;
 
   /*
@@ -100,6 +101,7 @@ function NotesBook() {
       ;
 
       my.notes(showNotes);
+      my.extremes(hideExtremes);
       my.combine(combineVoices);
       my.ribbons(selectedRibbon);
 
@@ -174,11 +176,18 @@ function NotesBook() {
       return my;
     } // my.hilite()
   ;
-  my.extremes = function() {
+  my.extremes = function(_) {
       var music = voices.selectAll(".extreme-plain")
         , vis = music.style("display")
       ;
-      music.style("display", vis === "inline" ? "none" : "inline");
+
+      // Argument can be null if menu was previously disabled
+      if (_ === null) {
+        _ = !hideExtremes;
+      }
+
+      music.style("display", _ ? "none" : "inline");
+      hideExtremes = _;
     } // my.extremes()
   ;
   my.zoom = function(_) {

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -236,7 +236,7 @@ function NotesBook() {
 
       // If notes are turned off and no ribbon is enabled, show default ribbon
       if (!_ && !showRibbon) {
-        my.ribbons("attack_density");
+        my.ribbons(selectedRibbon);
       }
 
       showNotes = _;
@@ -250,6 +250,35 @@ function NotesBook() {
               return d.toLowerCase() === arg ? "inline" : "none";
             })
       ;
+      if (arg !== "all") {
+        document.getElementById("show-ribbon").checked = true;
+        document.getElementById("select-ribbon").setAttribute("style", "display: inline");
+        if (arg == "attack_density") {
+          // Don't show staves for rhythmic density ribbon if notes are off
+          if (!showNotes) {
+            d3.selectAll(".refline")
+              .style("display", "none")
+            ;
+          }
+          // Disable Combine Voices option for rhythmic density ribbon
+          document.getElementById("combine-voices").checked = false;
+          document.getElementById("combine-ui").setAttribute("style", "display: none");
+          my.combine(false);
+        } else {
+          // Always show staves for melodic ribbon, enable Combine Voices opt
+          d3.selectAll(".refline")
+            .style("display", "inline")
+          ;
+          document.getElementById("combine-ui").setAttribute("style", "display: inline");
+        }
+        showRibbon = true;
+        selectedRibbon = arg;
+      } else {
+        // If no ribbon is displayed, notes and staves should be enabled
+        document.getElementById("show-notes").checked = true;
+        my.notes(true);
+        showRibbon = false;
+      }
     } // my.ribbons()
   ;
 

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -95,12 +95,14 @@ function NotesBook() {
               d3.select(this)
                   .call(score)
                   .call(ribbon.x(x).y(y))
-              // Initially, don't show the ribbons
-                .selectAll(".ribbon")
-                  .style("display", "none")
               ;
             })
       ;
+
+      my.notes(showNotes);
+      my.combine(combineVoices);
+      my.ribbons(selectedRibbon);
+      
       window.onresize = function(event) { markings.calibrate(); };
   } // my() - Main function object
 


### PR DESCRIPTION
These changes implement the requested updates to how the site menu interacts with the ribbon and note visualizations. The general structure of the prototype site code was maintained, with the exception of adding variables and updating the main render and setter/getter functions in `notesbook.js` to manage state settings more sustainably.
Specific issues addressed:
#193 - Rhythmic Activity ribbon should default to separated voices view (see also #197)
#195 - Remove pitch labels and staff from Rhythmic Activity ribbon (unless Notes turned on)
#197 - "Separate Voices" should be default (checkbox label becomes "Combine Voices")
#198 - Viz should default to "Rhythmic Activity" ribbon view (see #193, #195, #197)
#199 - "Show Notes" deselected by default; staves appear whenever notes are visible
#200 - "Hide Extreme Notes" option should only appear after "Show Notes" is selected; label and behavior of the option changed from previous "Highlight Extreme Notes"
#201 - "Show Notes" should be automatically selected if "Show Ribbon" is deselected (and vice versa)
#209 - Current display settings should be retained and applied when a new song/score is loaded