### PR TITLE
Center Rhythmic Activity ribbon when no notes are shown; increase amplitude

### DIFF
--- a/js/dev/baton.js
+++ b/js/dev/baton.js
@@ -18,6 +18,7 @@ var notesBook = NotesBook().svg(d3.select("#notesbook").select("svg"))
           , "combine-voices"
           , "selected"
           , "show-extremes"
+          , "select-ribbon"
           , "show-ribbon"
           , "show-notes"
         )
@@ -151,7 +152,8 @@ function createSignals() {
         .on("show-notes",      notesBook.notes)
         .on("show-extremes",   notesBook.extremes)
         .on("hilite",          notesBook.hilite)
-        .on("show-ribbon",     notesBook.ribbons)
+        .on("show-ribbon",     notesBook.toggleRibbons)
+        .on("select-ribbon",   notesBook.ribbons)
         .on("combine-voices",  notesBook.combine)
         .on("zoom",            notesBook.zoom)
     ;
@@ -188,17 +190,15 @@ function connectSignalsToDOM() {
     d3.select("#ribbons-ui").each(function() {
       var check = d3.select(this).select("input")
         , choice = d3.select(this).select("select")
-        , callback = check.node().id // callback name == checkbox 'id'
       ;
 
       check.on("change", function(d) {
           choice.style("display", this.checked ? null : "none");
-          var value = choice.node().value;
-          signal.call(callback, this, this.checked ? value : this.value);
+          signal.call("show-ribbon", this, this.checked);
         })
       ;
       choice.on("change", function() {
-          signal.call(callback, this, this.value);
+          signal.call("select-ribbon", this, this.value);
         })
       ;
     });

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -220,10 +220,13 @@ function NotesBook() {
       var music = voices.selectAll(".notes")
         , vis = music.style("display")
       ;
+
       // Argument can be null if menu was previously disabled
       if (_ === null) {
         _ = vis !== "inline";
       }
+
+      document.getElementById("show-notes").checked = _;
 
       music.style("display", _ ? "inline" : "none");
       // Only display "Hide Extreme Notes" when "Show Notes" is selected
@@ -235,71 +238,80 @@ function NotesBook() {
 
       showNotes = _;
 
-      if (!showRibbon && showNotes) {
+      // Notes are always enabled when ribbon is not, so make sure the
+      // staves are also displayed.
+      if (!showRibbon) {
         d3.selectAll(".refline")
           .style("display", "inline")
         ;
       }
 
+      // Show the ribbon if notes are being hidden
       if (!_ && !showRibbon) {
-        showRibbon = true;
-        document.getElementById("show-ribbon").checked = true;
+        my.toggleRibbons(true);
         my.ribbons(selectedRibbon);
+      // Attack density ribbon is "centered" on middle C when notes are hidden
       } else if (showRibbon && selectedRibbon == "attack_density" && !_) {
         my.ribbons("attack_density_centered");
+      // Attack density ribbon aligns with notes when they are shown
       } else if (showRibbon && selectedRibbon == "attack_density_centered" && _) {
         my.ribbons("attack_density");
       }
 
     } // my.notes()
   ;
+  my.toggleRibbons = function(_) {
+
+      showRibbon = _;
+      document.getElementById("show-ribbon").checked = showRibbon;
+      document.getElementById("select-ribbon").setAttribute("style", "display: " + (showRibbon ? "inline" : "none"));
+      if (showRibbon) {
+        my.ribbons(selectedRibbon);
+      } else {
+        voices.selectAll(".ribbon")
+          .style("display", "none");
+        // Always show notes if ribbons are hidden
+        my.notes(true);
+      }
+
+    } // my.toggleRibbons()
+  ;
   my.ribbons = function(arg) {
 
-      if (arg !== "all") {
-        document.getElementById("show-ribbon").checked = true;
-        document.getElementById("select-ribbon").setAttribute("style", "display: inline");
-        if ((arg == "attack_density") || (arg == "attack_density_centered")) {
-          // Don't show staves for rhythmic density ribbon if notes are off
-          if (!showNotes) {
-            d3.selectAll(".refline")
-              .style("display", "none")
-            ;
-            arg = "attack_density_centered";
-          } else {
-            d3.selectAll(".refline")
-              .style("display", "inline")
-            ;
-            arg = "attack_density";
-          }
-          // Disable Combine Voices option for rhythmic density ribbon
-          document.getElementById("combine-voices").checked = false;
-          document.getElementById("combine-ui").setAttribute("style", "display: none");
-          my.combine(false);
+      if ((arg == "attack_density") || (arg == "attack_density_centered")) {
+        // Don't show staves for rhythmic density ribbon if notes are off
+        if (!showNotes) {
+          d3.selectAll(".refline")
+            .style("display", "none")
+          ;
+          arg = "attack_density_centered";
         } else {
-          // Always show staves for melodic ribbon, enable Combine Voices opt
           d3.selectAll(".refline")
             .style("display", "inline")
           ;
-          document.getElementById("combine-ui").setAttribute("style", "display: inline");
+          arg = "attack_density";
         }
-        if (showNotes) {
-          voices.selectAll(".notes").style("display", "inline");
-        }
-        showRibbon = true;
-        selectedRibbon = arg;
+        // Disable Combine Voices option for rhythmic density ribbon
+        document.getElementById("combine-voices").checked = false;
+        document.getElementById("combine-ui").setAttribute("style", "display: none");
+        my.combine(false);
       } else {
-        // If no ribbon is displayed, notes and staves should be enabled
-        document.getElementById("show-notes").checked = true;
-        voices.selectAll(".notes").style("display", "inline");
-        showNotes = true;
-        showRibbon = false;
+        // Always show staves for melodic ribbon, enable Combine Voices opt
+        d3.selectAll(".refline")
+          .style("display", "inline")
+        ;
+        document.getElementById("combine-ui").setAttribute("style", "display: inline");
       }
+
       // TODO move this into render function, introduce variable.
       voices.selectAll(".ribbon")
-      .style("display", function(d) {
-          return d.toLowerCase() === arg ? "inline" : "none";
+        .style("display", function(d) {
+          return (d.toLowerCase() === arg) && showRibbon ? "inline" : "none";
         })
       ;
+
+      selectedRibbon = arg;
+
     } // my.ribbons()
   ;
 

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -30,9 +30,15 @@ function NotesBook() {
       if(!data) return;
 
       x.domain([0, getTime.scoreLength(data)]);
-      y.domain(d3.range(data.minpitch.b7, data.maxpitch.b7 + 1))
-          .padding(0.2)
-      ;
+
+      /* Center the Y domain around middle C, but if all of the notes are above
+       * or below middle C, limit the domain to that half
+       */
+      var maxRangeFromMC = Math.max(Math.max(0, data.maxpitch.b7 - 28), Math.max(0, 28 - data.minpitch.b7));
+      var minPitch = (data.minpitch.b7 <= 28) ? 28 - maxRangeFromMC : 28;
+      var maxPitch = (data.maxpitch.b7 >= 28) ? 28 + maxRangeFromMC + 1 : 29;
+      y.domain(d3.range(minPitch, maxPitch))
+
       x.range(x.domain().map(scaleup));
       y.range(d3.extent(y.domain()).reverse().map(scaleup));
 

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -19,7 +19,7 @@ function NotesBook() {
     , showNotes = false
     , combineVoices = false
     , showRibbon = true
-    , selectedRibbon = "attack_density"
+    , selectedRibbon = "attack_density_centered"
     , hideExtremes = false
   ;
 
@@ -229,39 +229,47 @@ function NotesBook() {
       // Only display "Hide Extreme Notes" when "Show Notes" is selected
       d3.select(document.getElementById("show-notes").parentNode.nextElementSibling).style("display", _ ? "inline" : "none");
 
-      // Show staff lines/labels if melodic ribbon is selected
-      // or if no ribbons are shown (meaning notes must be shown)
-      if (!showRibbon || selectedRibbon != "standard_deviation") {
+      // Toggle staff lines/labels with notes if rhythmic activity ribbon is
+      // selected. Also, if no ribbon is selected, notes (and therefore)
+      // staff lines/labels will be enabled.
+
+      showNotes = _;
+
+      if (!showRibbon && showNotes) {
         d3.selectAll(".refline")
-          .style("display", _ ? "inline" : "none");
+          .style("display", "inline")
         ;
       }
 
-      // If notes are turned off and no ribbon is enabled, show default ribbon
       if (!_ && !showRibbon) {
+        showRibbon = true;
+        document.getElementById("show-ribbon").checked = true;
         my.ribbons(selectedRibbon);
+      } else if (showRibbon && selectedRibbon == "attack_density" && !_) {
+        my.ribbons("attack_density_centered");
+      } else if (showRibbon && selectedRibbon == "attack_density_centered" && _) {
+        my.ribbons("attack_density");
       }
 
-      showNotes = _;
     } // my.notes()
   ;
   my.ribbons = function(arg) {
 
-      // TODO move this into render function, introduce variable.
-      voices.selectAll(".ribbon")
-          .style("display", function(d) {
-              return d.toLowerCase() === arg ? "inline" : "none";
-            })
-      ;
       if (arg !== "all") {
         document.getElementById("show-ribbon").checked = true;
         document.getElementById("select-ribbon").setAttribute("style", "display: inline");
-        if (arg == "attack_density") {
+        if ((arg == "attack_density") || (arg == "attack_density_centered")) {
           // Don't show staves for rhythmic density ribbon if notes are off
           if (!showNotes) {
             d3.selectAll(".refline")
               .style("display", "none")
             ;
+            arg = "attack_density_centered";
+          } else {
+            d3.selectAll(".refline")
+              .style("display", "inline")
+            ;
+            arg = "attack_density";
           }
           // Disable Combine Voices option for rhythmic density ribbon
           document.getElementById("combine-voices").checked = false;
@@ -274,14 +282,24 @@ function NotesBook() {
           ;
           document.getElementById("combine-ui").setAttribute("style", "display: inline");
         }
+        if (showNotes) {
+          voices.selectAll(".notes").style("display", "inline");
+        }
         showRibbon = true;
         selectedRibbon = arg;
       } else {
         // If no ribbon is displayed, notes and staves should be enabled
         document.getElementById("show-notes").checked = true;
-        my.notes(true);
+        voices.selectAll(".notes").style("display", "inline");
+        showNotes = true;
         showRibbon = false;
       }
+      // TODO move this into render function, introduce variable.
+      voices.selectAll(".ribbon")
+      .style("display", function(d) {
+          return d.toLowerCase() === arg ? "inline" : "none";
+        })
+      ;
     } // my.ribbons()
   ;
 

--- a/js/dev/ribbon.js
+++ b/js/dev/ribbon.js
@@ -121,23 +121,22 @@ function Ribbon() {
            });
     } // modes.STANDARD_DEVIATION()
 
-    modes.ATTACK_DENSITY = function(data) {
+    var densityGenerator = function(data, centered) {
 
       // Use the following fixed values for the attack density computation,
       // as these specific values were prescribed by Josquin project leads.
       var interval = 2 // Compute the density for a window of 2 seconds.
         , step = 1 // Compute values for each second.
-        , scaleFactor = 0.3 // Make the shape a bit thinner.
+        , scaleFactor = 0.4 // Make the shape a bit thinner.
       ;
 
-      // For steps in which there are no notes in the interval,
-      // An empty interval at the previous average is used.
-      var previousMean = data[0].pitch.b7;
-
       // Compute the mean pitch across all notes for this voice.
-      var overallMean = d3.mean(data.map(function (d) {
-        return d.pitch.b7;
-      }));
+      var overallMean = 28;
+      if (!centered) {
+        var overallMean = d3.mean(data.map(function (d) {
+          return d.pitch.b7;
+        }));
+      }
 
       return d3.range(x.domain()[0], x.domain()[1] + step, step)
         .map(function (x){
@@ -162,8 +161,6 @@ function Ribbon() {
             .map(function (d){ return d.pitch.b7; })
           ;
 
-          // At each iteration of this function,
-          // we'll compute the mean and standard deviation.
           var mean = overallMean
             , density;
 
@@ -194,12 +191,6 @@ function Ribbon() {
 
           density *= scaleFactor;
 
-
-          // Stash the previous average for next time around,
-          // whatever it may be, for use in the case that
-          // the set of notes in the window is empty.
-          //previousMean = mean;
-
           // Return an objects that represents this slice of the ribbon.
           return {
               x: x
@@ -207,7 +198,10 @@ function Ribbon() {
             , y0: mean - density
           };
         });
-    } // modes.ATTACK_DENSITY()
+    } // densityGenerator()
+
+    modes.ATTACK_DENSITY = function(data) { return densityGenerator(data, false); };
+    modes.ATTACK_DENSITY_CENTERED = function(data) { return densityGenerator(data, true); };
 
     /*
     ** Internal Helper Functions


### PR DESCRIPTION
There's no issue for the primary change in this PR (moving the Rhythmic Activity ribbon to the center of the staff for each voice when Show Notes is not selected), but it also attempts to address #196 (increase amplitude of ribbons) and also supersedes #194 (move separated voices closer together vertically), by introducing a new per-voice layout regime in which the staff domain of each voice is centered around middle C and expanded to encompass the highest and lowest note of any voice. This doesn't necessarily make the separated voices layout less vertically sparse, but it does make them less skewed, and allows the Rhythmic Activity ribbon to have a larger amplitude when centered on middle C.