### PR TITLE
Clear out voices and legends when loading a new song

### DIFF
--- a/js/dev/baton.js
+++ b/js/dev/baton.js
@@ -109,6 +109,10 @@ function load_song(work) {
 
             // Parse the raw JSON and pass it to chartify.
             currentScore = parseJSON(proll);
+
+            document.querySelector("#voices").innerHTML = "";
+            document.querySelector("#legend").innerHTML = "";
+
             chartify();
           })
     ;


### PR DESCRIPTION
This circumvents a bug occurring when, for example, a song with many voices (e.g., Jos3002, with 6 voices + aggregate) is loaded after viewing a song with fewer voices (Jos2107, 4 + aggregate). Due to the D3 merge logic used to populate the voices and legend, the voice labels and colors for the first song (4 + aggregate) would be applied to the first 5 voices of the second song, with the remaining 2 voices (voice 6 + aggregate) added after them.