### PR TITLE
Adjust combine-voices UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -130,3 +130,20 @@ select[disabled] {
 .refline--C4 line {
     stroke-dasharray: 4 4;
 }
+
+label.disabled {
+    color: grey;
+    cursor: not-allowed;
+}
+
+#ribbons-ui {
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+#ribbons-ui label,
+#ribbons-ui select {
+    margin-bottom: 0;
+    margin-right: 10px;
+}

--- a/index.html
+++ b/index.html
@@ -80,12 +80,10 @@
               <option value="attack_density" selected>Rhythmic Activity</option>
             </optgroup>
           </select>
-        </div><!--/#ribbons-ui-->
-        <div id="combine-ui" style="display: none">
           <label for="combine-voices">
             <input id="combine-voices" type="checkbox" autocomplete="off"> Combine Voices
           </label>
-        </div>
+        </div><!--/#ribbons-ui-->
         <div id="notes-ui">
           <label for="show-notes">
             <input id="show-notes" type="checkbox" autocomplete="off"> Show Notes

--- a/js/dev/baton.js
+++ b/js/dev/baton.js
@@ -179,7 +179,7 @@ function createSignals() {
 function connectSignalsToDOM() {
 
     // Combine/Separate Voices
-    d3.select("#combine-ui").selectAll("input")
+    d3.select("input#combine-voices")
         .on("change", function(d) {
             signal.call(this.id, this, this.checked)
         })
@@ -202,7 +202,7 @@ function connectSignalsToDOM() {
       ;
 
       check.on("change", function(d) {
-          choice.style("display", this.checked ? null : "none");
+          // choice.style("display", this.checked ? null : "none");
           signal.call("show-ribbon", this, this.checked);
         })
       ;

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -300,7 +300,10 @@ function NotesBook() {
 
       showRibbon = _;
       document.getElementById("show-ribbon").checked = showRibbon;
-      document.getElementById("select-ribbon").setAttribute("style", "display: " + (showRibbon ? "inline" : "none"));
+      document.getElementById("select-ribbon").disabled = !showRibbon;
+
+      var combineVoicesCheckbox = document.getElementById("combine-voices");
+
       if (showRibbon) {
         my.ribbons(selectedRibbon);
       } else {
@@ -308,12 +311,15 @@ function NotesBook() {
           .style("display", "none");
         // Always show notes if ribbons are hidden
         my.notes(true);
+        combineVoicesCheckbox.disabled = false;
+        combineVoicesCheckbox.parentElement.classList.remove("disabled");
       }
 
     } // my.toggleRibbons()
   ;
   my.ribbons = function(arg) {
 
+      var combineVoicesCheckbox = document.getElementById("combine-voices");
       if ((arg == "attack_density") || (arg == "attack_density_centered")) {
         // Don't show staves for rhythmic density ribbon if notes are off
         if (!showNotes) {
@@ -328,15 +334,17 @@ function NotesBook() {
           arg = "attack_density";
         }
         // Disable Combine Voices option for rhythmic density ribbon
-        document.getElementById("combine-voices").checked = false;
-        document.getElementById("combine-ui").setAttribute("style", "display: none");
+        combineVoicesCheckbox.checked = false;
+        combineVoicesCheckbox.disabled = true;
+        combineVoicesCheckbox.parentElement.classList.add("disabled");
         my.combine(false);
       } else {
         // Always show staves for melodic ribbon, enable Combine Voices opt
         d3.selectAll(".refline")
           .style("display", "inline")
         ;
-        document.getElementById("combine-ui").setAttribute("style", "display: inline");
+        combineVoicesCheckbox.disabled = false;
+        combineVoicesCheckbox.parentElement.classList.remove("disabled");
       }
 
       // TODO move this into render function, introduce variable.


### PR DESCRIPTION
This PR moves the "combine voices" checkbox to the same line as the ribbon selector, and disables it when appropriate rather than hiding it altogether.  It also disables the ribbon selector rather than hiding it, and allow combining voices when the ribbons are not shown.