### PR TITLE
Better support for SVG prettifying on export

### DIFF
--- a/js/dev/svg-export-processing.js
+++ b/js/dev/svg-export-processing.js
@@ -1,25 +1,30 @@
 /* exported prettifyXml, cleanSvg, addSvgPadding, processSymbols, safariNamespaceFix */
 var prettifyXml = function(sourceXml) {
-  if (!XSLTProcessor || !XSLTProcessor.importStylesheet) return sourceXml;
-  var xmlDoc = new DOMParser().parseFromString(sourceXml, 'application/xml');
-  var xsltDoc = new DOMParser().parseFromString([
-    '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">',
-    '  <xsl:strip-space elements="*"/>',
-    '  <xsl:template match="para[content-style][text()]">',
-    '    <xsl:value-of select="normalize-space(.)"/>',
-    '  </xsl:template>',
-    '  <xsl:template match="node()|@*">',
-    '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
-    '  </xsl:template>',
-    '  <xsl:output indent="yes"/>',
-    '</xsl:stylesheet>',
-  ].join('\n'), 'application/xml');
 
-  var xsltProcessor = new XSLTProcessor();    
-  xsltProcessor.importStylesheet(xsltDoc);
-  var resultDoc = xsltProcessor.transformToDocument(xmlDoc);
-  var resultXml = new XMLSerializer().serializeToString(resultDoc);
-  return resultXml;
+  try {  
+    var xmlDoc = new DOMParser().parseFromString(sourceXml, 'application/xml');
+    var xsltDoc = new DOMParser().parseFromString([
+      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">',
+      '  <xsl:strip-space elements="*"/>',
+      '  <xsl:template match="para[content-style][text()]">',
+      '    <xsl:value-of select="normalize-space(.)"/>',
+      '  </xsl:template>',
+      '  <xsl:template match="node()|@*">',
+      '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
+      '  </xsl:template>',
+      '  <xsl:output indent="yes"/>',
+      '</xsl:stylesheet>',
+    ].join('\n'), 'application/xml');
+    
+    var xsltProcessor = new XSLTProcessor();
+    xsltProcessor.importStylesheet(xsltDoc);
+    var resultDoc = xsltProcessor.transformToDocument(xmlDoc);
+    var resultXml = new XMLSerializer().serializeToString(resultDoc);
+    return resultXml;
+  } 
+  catch(error) {
+    return sourceXml;
+  }
 };
 
 var _roundValue = function(valueAsString) {


### PR DESCRIPTION
There are browsers (Brave was the one I found) that can support the XSLT transformations but fail the feature check because the methods are exposed on instances but not on the class constructor -- however, FF also exposes the needed methods on instances but fails the transform :(.  So I'm wrapping the whole thing in `try {} catch {}` instead, and having done with it :)