### PR TITLE
Allow Show Notes and Highlight Extreme Notes to be selected independently.

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
           <label for="show-notes">
             <input id="show-notes" type="checkbox" autocomplete="off"> Show Notes
           </label>
-          <label for="show-extremes" style="display: none">
+          <label for="show-extremes">
             <input id="show-extremes" type="checkbox" autocomplete="off"> Highlight Extreme Notes
           </label>
         </div><!--.btn-group#notes-ui-->

--- a/js/dev/baton.js
+++ b/js/dev/baton.js
@@ -186,13 +186,16 @@ function connectSignalsToDOM() {
     ;
 
     // Show/Hide Notes and Extreme Highlights
-    d3.select("#notes-ui").selectAll("input")
+    d3.select("input#show-notes")
         .on("change", function(d) {
-            d3.select(this.parentNode.nextElementSibling)
-                .style("display", this.checked ? null : "none")
-            ;
-            signal.call(this.id, this, null);
-          })
+          signal.call(this.id, this, this.checked)
+        })
+    ;
+
+    d3.select("input#show-extremes")
+        .on("change", function(d) {
+          signal.call(this.id, this, this.checked)
+        })
     ;
 
     // Show/Hide ribbons

--- a/js/dev/notesbook.js
+++ b/js/dev/notesbook.js
@@ -201,6 +201,9 @@ function NotesBook() {
           // And hide the staff lines unless the melodic ribbon is shown
           d3.selectAll(".refline").style("display", "none");
         }
+        // Enable the selected ribbon if all notes are hidden
+        my.toggleRibbons(true);
+        my.ribbons(selectedRibbon);
       } else {
         d3.selectAll(".refline").style("display", "inline");
         if (highlightExtremes) {
@@ -307,7 +310,7 @@ function NotesBook() {
       }
 
       // Show the ribbon if notes are being hidden
-      if (!_ && !showRibbon) {
+      if (!_ && !showRibbon && !highlightExtremes) {
         my.toggleRibbons(true);
         my.ribbons(selectedRibbon);
       // Attack density ribbon is "centered" on middle C when notes are hidden
@@ -341,7 +344,10 @@ function NotesBook() {
         voices.selectAll(".ribbon")
           .style("display", "none");
         // Always show notes if ribbons are hidden
-        my.notes(true);
+        // but don't bother if extreme notes are already shown
+        if (!highlightExtremes) {
+          my.notes(true);
+        }
         combineVoicesCheckbox.disabled = false;
         combineVoicesCheckbox.parentElement.classList.remove("disabled");
       }

--- a/js/dev/svg-export-processing.js
+++ b/js/dev/svg-export-processing.js
@@ -54,6 +54,9 @@ var cleanSvg = function(svg) {
 
   svg.querySelectorAll("g.notes").forEach(function(elem) {
     var firstNote = elem.querySelector("rect.note:not(.extreme)");
+    if (!firstNote) { // For when only extreme notes are shown
+      firstNote = elem.querySelector("rect.note");
+    }
     elem.setAttribute("fill", firstNote.style.fill);
     elem.setAttribute("fill-opacity", firstNote.style.fillOpacity);
     elem.setAttribute("stroke", firstNote.style.stroke);

--- a/js/dev/svg-export-processing.js
+++ b/js/dev/svg-export-processing.js
@@ -54,9 +54,7 @@ var cleanSvg = function(svg) {
 
   svg.querySelectorAll("g.notes").forEach(function(elem) {
     var firstNote = elem.querySelector("rect.note:not(.extreme)");
-    if (!firstNote) { // For when only extreme notes are shown
-      firstNote = elem.querySelector("rect.note");
-    }
+    if (!firstNote) return; // For when only extreme notes are shown
     elem.setAttribute("fill", firstNote.style.fill);
     elem.setAttribute("fill-opacity", firstNote.style.fillOpacity);
     elem.setAttribute("stroke", firstNote.style.stroke);

--- a/js/dev/svg-export-processing.js
+++ b/js/dev/svg-export-processing.js
@@ -63,9 +63,9 @@ var cleanSvg = function(svg) {
 
   svg.querySelectorAll("rect.extreme").forEach(function(elem) {
     elem.setAttribute("fill", elem.style.fill);
-    elem.setAttribute("fill-opacity", elem.style.fillOpacity);
+    elem.setAttribute("fill-opacity", elem.style.fillOpacity || 1);
     elem.setAttribute("stroke", elem.style.stroke);
-    elem.setAttribute("stroke-width", 1);
+    elem.setAttribute("stroke-width", elem.style.strokeWidth || 1);
   });
 
   svg.querySelectorAll("svg.subdued > g").forEach(function(elem) {


### PR DESCRIPTION
This addresses point 2 of #232. Tricky things that this PR needs to handle include a) managing the intricate dance of ribbon and note checkboxes/settings so that the score canvas is always showing either a ribbon or (a few) notes, and b) a slight tweak to the SVG export code.